### PR TITLE
Nested variable override

### DIFF
--- a/src/Exceptions/UndefinedVariableException.php
+++ b/src/Exceptions/UndefinedVariableException.php
@@ -4,8 +4,8 @@ namespace Keepsuit\Liquid\Exceptions;
 
 class UndefinedVariableException extends LiquidException
 {
-    public function __construct(string $method)
+    public function __construct(string $variable)
     {
-        parent::__construct("Variable `$method` not found");
+        parent::__construct("Variable `$variable` not found");
     }
 }

--- a/tests/Integration/TemplateTest.php
+++ b/tests/Integration/TemplateTest.php
@@ -145,9 +145,9 @@ test('undefined variables', function () {
         ->{0}->toBeInstanceOf(UndefinedVariableException::class)
         ->{0}->getMessage()->toBe('Variable `y` not found')
         ->{1}->toBeInstanceOf(UndefinedVariableException::class)
-        ->{1}->getMessage()->toBe('Variable `b` not found')
+        ->{1}->getMessage()->toBe('Variable `z.b` not found')
         ->{2}->toBeInstanceOf(UndefinedVariableException::class)
-        ->{2}->getMessage()->toBe('Variable `d` not found');
+        ->{2}->getMessage()->toBe('Variable `z.c.d` not found');
 });
 
 test('null value does not throw exception', function () {

--- a/tests/Integration/VariableTest.php
+++ b/tests/Integration/VariableTest.php
@@ -29,6 +29,39 @@ test('generator variable with lookup', function () {
     assertTemplateResult('1', '{{test.first}}', ['test' => generator()]);
 });
 
+test('variable override', function () {
+    $templateFactory = new \Keepsuit\Liquid\TemplateFactory();
+    $templateFactory->registerTag(\Keepsuit\Liquid\Tests\Stubs\VariableOverrideTag::class);
+
+    assertTemplateResult('old|new|old', <<<LIQUID
+        {{ test }}|
+        {%- override test "new" -%}
+        {{ test }}|
+        {%- endoverride -%}
+        {{ test }}
+        LIQUID, [
+        'test' => 'old',
+    ], factory: $templateFactory);
+});
+
+test('variable nested override', function () {
+    $templateFactory = new \Keepsuit\Liquid\TemplateFactory();
+    $templateFactory->registerTag(\Keepsuit\Liquid\Tests\Stubs\VariableOverrideTag::class);
+
+    assertTemplateResult('old_a,old_b|old_a,new_b|old_a,old_b', <<<LIQUID
+        {{ test.a }},{{ test.b }}|
+        {%- override test.b "new_b" -%}
+        {{ test.a }},{{ test.b }}|
+        {%- endoverride -%}
+        {{ test.a }},{{ test.b }}
+        LIQUID, [
+        'test' => [
+            'a' => 'old_a',
+            'b' => 'old_b',
+        ],
+    ], factory: $templateFactory);
+});
+
 function generator(): Generator
 {
     yield '1';

--- a/tests/Integration/VariableTest.php
+++ b/tests/Integration/VariableTest.php
@@ -33,7 +33,7 @@ test('variable override', function () {
     $templateFactory = new \Keepsuit\Liquid\TemplateFactory();
     $templateFactory->registerTag(\Keepsuit\Liquid\Tests\Stubs\VariableOverrideTag::class);
 
-    assertTemplateResult('old|new|old', <<<LIQUID
+    assertTemplateResult('old|new|old', <<<'LIQUID'
         {{ test }}|
         {%- override test "new" -%}
         {{ test }}|
@@ -48,7 +48,7 @@ test('variable nested override', function () {
     $templateFactory = new \Keepsuit\Liquid\TemplateFactory();
     $templateFactory->registerTag(\Keepsuit\Liquid\Tests\Stubs\VariableOverrideTag::class);
 
-    assertTemplateResult('old_a,old_b|old_a,new_b|old_a,old_b', <<<LIQUID
+    assertTemplateResult('old_a,old_b|old_a,new_b|old_a,old_b', <<<'LIQUID'
         {{ test.a }},{{ test.b }}|
         {%- override test.b "new_b" -%}
         {{ test.a }},{{ test.b }}|

--- a/tests/Stubs/VariableOverrideTag.php
+++ b/tests/Stubs/VariableOverrideTag.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Keepsuit\Liquid\Tests\Stubs;
+
+use Keepsuit\Liquid\Exceptions\SyntaxException;
+use Keepsuit\Liquid\Nodes\BodyNode;
+use Keepsuit\Liquid\Nodes\Variable;
+use Keepsuit\Liquid\Nodes\VariableLookup;
+use Keepsuit\Liquid\Parse\TagParseContext;
+use Keepsuit\Liquid\Render\RenderContext;
+use Keepsuit\Liquid\TagBlock;
+
+class VariableOverrideTag extends TagBlock
+{
+    protected BodyNode $body;
+
+    protected Variable $variable;
+
+    protected mixed $value;
+
+    public function parse(TagParseContext $context): static
+    {
+        assert($context->body !== null);
+        $this->body = $context->body;
+
+        $this->variable = $context->params->variable();
+
+        $this->value = $context->params->expression();
+
+        $context->params->assertEnd();
+
+        return $this;
+    }
+
+    public function render(RenderContext $context): string
+    {
+        return $context->stack(function (RenderContext $context) {
+            $name = $this->variable->name;
+
+            $context->set(match (true) {
+                $name instanceof VariableLookup, is_string($name) => (string) $name,
+                default => throw new SyntaxException('Invalid variable name'),
+            }, $this->value);
+
+            return $this->body->render($context);
+        });
+    }
+
+    public static function tagName(): string
+    {
+        return 'override';
+    }
+}


### PR DESCRIPTION
With this PR we can override a nested variable (for example `product.name`) without overriding the entire variable.

There are breaking changes:
- `RenderContext::findVariable` will be renamed `RenderContext::findVariables` and will return an array of matching variables (sorted by priority)
- `RenderContext::lookupAndEvaluate` has been removed (the evaluation has been moved to `VariableLookup`)