### PR TITLE
Rename template factory setter methods and add getters

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Create a new template factory instance:
 ```php
 $factory = \Keepsuit\Liquid\TemplateFactory::new()
     // enable strict variables mode
-    ->strictVariables()
+    ->setStrictVariables()
     // rethrow exceptions instead of rendering them
-    ->rethrowExceptions()
+    ->setRethrowExceptions()
     // set filesystem used to load templates
     ->setFilesystem(new \Keepsuit\Liquid\FileSystems\LocalFileSystem(__DIR__ . '/views'));
 ```

--- a/src/TemplateFactory.php
+++ b/src/TemplateFactory.php
@@ -80,31 +80,46 @@ final class TemplateFactory
         return $this->filterRegistry;
     }
 
-    public function profile(bool $profile = true): TemplateFactory
+    public function setProfile(bool $profile = true): TemplateFactory
     {
         $this->profile = $profile;
 
         return $this;
     }
 
-    public function rethrowExceptions(bool $rethrowExceptions = true): TemplateFactory
+    public function getProfile(): bool
+    {
+        return $this->profile;
+    }
+
+    public function setRethrowExceptions(bool $rethrowExceptions = true): TemplateFactory
     {
         $this->rethrowExceptions = $rethrowExceptions;
 
         return $this;
     }
 
-    public function strictVariables(bool $strictVariables = true): TemplateFactory
+    public function getRethrowExceptions(): bool
+    {
+        return $this->rethrowExceptions;
+    }
+
+    public function setStrictVariables(bool $strictVariables = true): TemplateFactory
     {
         $this->strictVariables = $strictVariables;
 
         return $this;
     }
 
+    public function getStrictVariables(): bool
+    {
+        return $this->strictVariables;
+    }
+
     /**
      * Enable/disabled rethrowExceptions and strictVariables.
      */
-    public function debugMode(bool $debugMode = true): TemplateFactory
+    public function setDebugMode(bool $debugMode = true): TemplateFactory
     {
         $this->rethrowExceptions = $debugMode;
         $this->strictVariables = $debugMode;
@@ -218,20 +233,5 @@ final class TemplateFactory
     {
         return (new FilterRegistry())
             ->register(StandardFilters::class);
-    }
-
-    public function __get(string $name): mixed
-    {
-        $publicProperties = [
-            'profile',
-            'rethrowExceptions',
-            'strictVariables',
-        ];
-
-        if (in_array($name, $publicProperties)) {
-            return $this->{$name};
-        }
-
-        throw new \InvalidArgumentException("Property {$name} does not exist");
     }
 }

--- a/src/TemplateFactory.php
+++ b/src/TemplateFactory.php
@@ -12,11 +12,6 @@ use Keepsuit\Liquid\Render\ResourceLimits;
 use Keepsuit\Liquid\Support\FilterRegistry;
 use Keepsuit\Liquid\Support\TagRegistry;
 
-/**
- * @property-read bool $profile
- * @property-read bool $rethrowExceptions
- * @property-read bool $strictVariables
- */
 final class TemplateFactory
 {
     protected TagRegistry $tagRegistry;

--- a/tests/Integration/ProfilerTest.php
+++ b/tests/Integration/ProfilerTest.php
@@ -12,7 +12,7 @@ beforeEach(function () {
     $this->templateFactory = TemplateFactory::new()
         ->setFilesystem(new ProfilingFileSystem())
         ->registerTag(SleepTag::class)
-        ->profile();
+        ->setProfile();
 });
 
 test('context allows flagging profiling', function () {
@@ -189,7 +189,7 @@ function profileTemplate(string $source, array $assigns = []): ?Profiler
 {
     /** @var TemplateFactory $factory */
     $factory = test()->templateFactory;
-    $template = $factory->profile()->parseString($source);
+    $template = $factory->setProfile()->parseString($source);
     $template->render($factory->newRenderContext(
         staticEnvironment: $assigns,
     ));

--- a/tests/Integration/Tags/AssignTagTest.php
+++ b/tests/Integration/Tags/AssignTagTest.php
@@ -68,7 +68,7 @@ test('assign score exceeding resource limit', function () {
 
 test('assign score exceeding resource limit from composite object', function () {
     $factory = TemplateFactory::new()
-        ->rethrowExceptions();
+        ->setRethrowExceptions();
 
     $template = parseTemplate("{% assign foo = 'aaaa' | split: '' %}", factory: $factory);
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -53,7 +53,7 @@ function renderTemplate(
 ): string {
     $factory = $factory
         ->setFilesystem(new StubFileSystem(partials: $partials))
-        ->rethrowExceptions(! $renderErrors);
+        ->setRethrowExceptions(! $renderErrors);
 
     $template = $factory->parseString($template);
 
@@ -81,7 +81,7 @@ function streamTemplate(
 ): Generator {
     $factory = $factory
         ->setFilesystem(new StubFileSystem(partials: $partials))
-        ->rethrowExceptions(! $renderErrors);
+        ->setRethrowExceptions(! $renderErrors);
 
     $template = $factory->parseString($template);
 

--- a/tests/Unit/TemplateTest.php
+++ b/tests/Unit/TemplateTest.php
@@ -23,12 +23,12 @@ test('get registered tags', function () {
 
 test('template factory settings', function () {
     $factory = TemplateFactory::new()
-        ->rethrowExceptions()
-        ->strictVariables()
-        ->profile();
+        ->setRethrowExceptions()
+        ->setStrictVariables()
+        ->setProfile();
 
     expect($factory)
-        ->rethrowExceptions->toBeTrue()
-        ->strictVariables->toBeTrue()
-        ->profile->toBeTrue();
+        ->getRethrowExceptions()->toBeTrue()
+        ->getStrictVariables()->toBeTrue()
+        ->getProfile()->toBeTrue();
 });


### PR DESCRIPTION
## Breaking changes
- Renamed `TemplateFactory` setter methods
  - `strictVariables` -> `setStrictVariables` 
  - `rethrowExceptions` -> `setRethrowExceptions`
  - `profile` -> `setProfile`
  - `debugMode` -> `setDebugMode`
- Added getters: `getStrictVariables` , `getRethrowExceptions`, `getProfile`
- Removed property accessors: `profile`, `rethrowExceptions`, `strictVariables`