### PR TITLE
Strict variables improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,7 @@
     "scripts": {
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage",
-        "format": "vendor/bin/pint",
-        "lint": "vendor/bin/phpstan analyse",
+        "lint": "vendor/bin/pint && vendor/bin/phpstan analyse",
         "benchmark": "vendor/bin/phpbench run --report=aggregate --php-config=\"opcache.enable: 1, opcache.enable_cli: 1\"",
         "profile": "vendor/bin/phpbench xdebug:profile"
     },

--- a/performance/Shopify/PaginateTag.php
+++ b/performance/Shopify/PaginateTag.php
@@ -55,6 +55,7 @@ class PaginateTag extends TagBlock
     {
         return $context->stack(function (RenderContext $context) {
             $currentPage = $context->get('current_page');
+            $currentPage = is_int($currentPage) ? $currentPage : 1;
 
             $collection = $context->get($this->collectionName);
             $collection = match (true) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,11 +10,9 @@ parameters:
         - tests/Stubs
     tmpDir: build/phpstan
     treatPhpDocTypesAsCertain: false
-    checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: true
     checkPhpDocMissingReturn: true
-    featureToggles:
-        disableCheckMissingIterableValueType: false
 
     ignoreErrors:
+        - identifier: missingType.iterableValue
         - '#Method .+ should return .+ but returns mixed#'

--- a/src/Nodes/VariableLookup.php
+++ b/src/Nodes/VariableLookup.php
@@ -6,7 +6,6 @@ use Keepsuit\Liquid\Contracts\CanBeEvaluated;
 use Keepsuit\Liquid\Contracts\HasParseTreeVisitorChildren;
 use Keepsuit\Liquid\Contracts\IsContextAware;
 use Keepsuit\Liquid\Exceptions\SyntaxException;
-use Keepsuit\Liquid\Exceptions\UndefinedVariableException;
 use Keepsuit\Liquid\Parse\LexerOptions;
 use Keepsuit\Liquid\Render\RenderContext;
 use Keepsuit\Liquid\Support\MissingValue;

--- a/src/Render/RenderContext.php
+++ b/src/Render/RenderContext.php
@@ -168,9 +168,6 @@ final class RenderContext
         return $this->get($key) !== null;
     }
 
-    /**
-     * @throws UndefinedVariableException
-     */
     public function findVariables(string $key): array
     {
         $variables = [];
@@ -182,10 +179,6 @@ final class RenderContext
         $variables[] = $this->internalContextLookup($this->sharedState->staticEnvironment, $key);
 
         $variables = array_values(array_filter($variables, fn (mixed $value) => ! $value instanceof MissingValue));
-
-        if ($variables === []) {
-            return $this->strictVariables ? throw new UndefinedVariableException($key) : [];
-        }
 
         foreach ($variables as $variable) {
             if ($variable instanceof IsContextAware) {

--- a/src/Render/RenderContext.php
+++ b/src/Render/RenderContext.php
@@ -14,7 +14,6 @@ use Keepsuit\Liquid\Exceptions\LiquidException;
 use Keepsuit\Liquid\Exceptions\ResourceLimitException;
 use Keepsuit\Liquid\Exceptions\StackLevelException;
 use Keepsuit\Liquid\Exceptions\StandardException;
-use Keepsuit\Liquid\Exceptions\UndefinedVariableException;
 use Keepsuit\Liquid\FileSystems\BlankFileSystem;
 use Keepsuit\Liquid\Interrupts\Interrupt;
 use Keepsuit\Liquid\Nodes\VariableLookup;

--- a/src/Support/FilterRegistry.php
+++ b/src/Support/FilterRegistry.php
@@ -45,7 +45,7 @@ class FilterRegistry
     }
 
     /**
-     * @throws UndefinedFilterException
+     * @throws UndefinedFilterException|UndefinedVariableException
      */
     public function invoke(RenderContext $context, string $filterName, mixed $value, mixed ...$args): mixed
     {

--- a/src/Support/FilterRegistry.php
+++ b/src/Support/FilterRegistry.php
@@ -5,6 +5,7 @@ namespace Keepsuit\Liquid\Support;
 use Keepsuit\Liquid\Contracts\IsContextAware;
 use Keepsuit\Liquid\Exceptions\InvalidArgumentException;
 use Keepsuit\Liquid\Exceptions\UndefinedFilterException;
+use Keepsuit\Liquid\Exceptions\UndefinedVariableException;
 use Keepsuit\Liquid\Render\RenderContext;
 
 class FilterRegistry
@@ -51,7 +52,15 @@ class FilterRegistry
         $filter = $this->filters[$filterName] ?? null;
 
         if ($filter !== null) {
-            return $filter($context, $value, ...$args);
+            try {
+                return $filter($context, $value, ...$args);
+            } catch (\TypeError $e) {
+                if ($value instanceof UndefinedVariable) {
+                    throw new UndefinedVariableException($value->variableName);
+                }
+
+                throw $e;
+            }
         }
 
         if ($context->strictVariables) {

--- a/src/Support/UndefinedVariable.php
+++ b/src/Support/UndefinedVariable.php
@@ -3,13 +3,11 @@
 namespace Keepsuit\Liquid\Support;
 
 use Keepsuit\Liquid\Contracts\AsLiquidValue;
-use Keepsuit\Liquid\Contracts\CanBeEvaluated;
 use Keepsuit\Liquid\Contracts\CanBeRendered;
 use Keepsuit\Liquid\Exceptions\UndefinedVariableException;
-use Keepsuit\Liquid\Nodes\VariableLookup;
 use Keepsuit\Liquid\Render\RenderContext;
 
-class UndefinedVariable implements CanBeRendered, AsLiquidValue
+class UndefinedVariable implements AsLiquidValue, CanBeRendered
 {
     public function __construct(public readonly string $variableName)
     {

--- a/src/Support/UndefinedVariable.php
+++ b/src/Support/UndefinedVariable.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Keepsuit\Liquid\Support;
+
+use Keepsuit\Liquid\Contracts\AsLiquidValue;
+use Keepsuit\Liquid\Contracts\CanBeEvaluated;
+use Keepsuit\Liquid\Contracts\CanBeRendered;
+use Keepsuit\Liquid\Exceptions\UndefinedVariableException;
+use Keepsuit\Liquid\Nodes\VariableLookup;
+use Keepsuit\Liquid\Render\RenderContext;
+
+class UndefinedVariable implements CanBeRendered, AsLiquidValue
+{
+    public function __construct(protected string $variableName)
+    {
+    }
+
+    public function render(RenderContext $context): string
+    {
+        if ($context->strictVariables) {
+            throw new UndefinedVariableException($this->variableName);
+        }
+
+        return '';
+    }
+
+    public function toLiquidValue(): string|int|float|bool|null
+    {
+        return null;
+    }
+}

--- a/src/Support/UndefinedVariable.php
+++ b/src/Support/UndefinedVariable.php
@@ -11,7 +11,7 @@ use Keepsuit\Liquid\Render\RenderContext;
 
 class UndefinedVariable implements CanBeRendered, AsLiquidValue
 {
-    public function __construct(protected string $variableName)
+    public function __construct(public readonly string $variableName)
     {
     }
 

--- a/tests/Integration/StandardFilterTest.php
+++ b/tests/Integration/StandardFilterTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Keepsuit\Liquid\Exceptions\ArithmeticException;
+use Keepsuit\Liquid\Support\UndefinedVariable;
 use Keepsuit\Liquid\Tests\Stubs\BooleanDrop;
 use Keepsuit\Liquid\Tests\Stubs\NumberDrop;
 use Keepsuit\Liquid\Tests\Stubs\TestDrop;
@@ -615,6 +616,17 @@ test('default', function () {
     assertTemplateResult('bar', "{{ drop | default: 'bar' }}", ['drop' => new BooleanDrop(false)]);
     assertTemplateResult('Yay', "{{ drop | default: 'bar' }}", ['drop' => new BooleanDrop(true)]);
 });
+
+test('default handle undefined variable', function (bool $strict) {
+    expect($this->filters->invoke($this->context, 'default', new UndefinedVariable('foo'), 'bar'))->toBe('bar');
+
+    assertTemplateResult('bar', '{{ foo | default: "bar" }}', strictVariables: $strict);
+    assertTemplateResult('bar', '{{ foo.x | default: "bar" }}', strictVariables: $strict);
+    assertTemplateResult('bar', '{{ foo.x.y | default: "bar" }}', strictVariables: $strict);
+})->with([
+    'default' => false,
+    'strict' => true,
+]);
 
 test('default handle false', function () {
     expect($this->filters->invoke($this->context, 'default', 'foo', 'bar', allow_false: true))->toBe('foo');

--- a/tests/Integration/Tags/IfTagTest.php
+++ b/tests/Integration/Tags/IfTagTest.php
@@ -96,6 +96,15 @@ test('if from variable', function () {
     assertTemplateResult(' YES ', '{% if foo.bar %} NO {% else %} YES {% endif %}', ['notfoo' => [], 'bar' => true]);
 });
 
+test('if undefined variable', function (bool $strict) {
+    assertTemplateResult(' NO ', '{% if var %} YES {% else %} NO {% endif %}', strictVariables: $strict);
+    assertTemplateResult(' YES ', '{% if var == null %} YES {% else %} NO {% endif %}', strictVariables: $strict);
+    assertTemplateResult(' NO ', '{% if var == false %} YES {% else %} NO {% endif %}', strictVariables: $strict);
+})->with([
+    'default' => false,
+    'strict' => true,
+]);
+
 test('nested if', function () {
     assertTemplateResult('', '{% if false %}{% if false %} NO {% endif %}{% endif %}');
     assertTemplateResult('', '{% if false %}{% if true %} NO {% endif %}{% endif %}');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -49,11 +49,13 @@ function renderTemplate(
     array $registers = [],
     array $partials = [],
     bool $renderErrors = false,
+    bool $strictVariables = false,
     TemplateFactory $factory = new TemplateFactory()
 ): string {
     $factory = $factory
         ->setFilesystem(new StubFileSystem(partials: $partials))
-        ->setRethrowExceptions(! $renderErrors);
+        ->setRethrowExceptions(! $renderErrors)
+        ->setStrictVariables($strictVariables);
 
     $template = $factory->parseString($template);
 
@@ -67,9 +69,9 @@ function renderTemplate(
 }
 
 /**
+ * @throws SyntaxException
  * @return Generator<string>
  *
- * @throws SyntaxException
  */
 function streamTemplate(
     string $template,
@@ -77,11 +79,13 @@ function streamTemplate(
     array $registers = [],
     array $partials = [],
     bool $renderErrors = false,
+    bool $strictVariables = false,
     TemplateFactory $factory = new TemplateFactory()
 ): Generator {
     $factory = $factory
         ->setFilesystem(new StubFileSystem(partials: $partials))
-        ->setRethrowExceptions(! $renderErrors);
+        ->setRethrowExceptions(! $renderErrors)
+        ->setStrictVariables($strictVariables);
 
     $template = $factory->parseString($template);
 
@@ -101,6 +105,7 @@ function assertTemplateResult(
     array $registers = [],
     array $partials = [],
     bool $renderErrors = false,
+    bool $strictVariables = false,
     TemplateFactory $factory = new TemplateFactory(),
 ): void {
     expect(renderTemplate(
@@ -109,6 +114,7 @@ function assertTemplateResult(
         registers: $registers,
         partials: $partials,
         renderErrors: $renderErrors,
+        strictVariables: $strictVariables,
         factory: $factory,
     ))->toBe($expected);
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -69,9 +69,9 @@ function renderTemplate(
 }
 
 /**
- * @throws SyntaxException
  * @return Generator<string>
  *
+ * @throws SyntaxException
  */
 function streamTemplate(
     string $template,


### PR DESCRIPTION
- Delay thrown of `UndefinedVariableException` to render phase instead of lookup phase.
- Allow to use undefined variable as condition (in `if`, `unless`, etc.), undefined variable are evaluated as `null`
- allow to set a fallback value with `default` filter (ex: `assing var = var | default: "default value"`)