### PR TITLE
Dynamic render tag

### DIFF
--- a/src/Render/RenderContext.php
+++ b/src/Render/RenderContext.php
@@ -312,13 +312,24 @@ final class RenderContext
         return $this->templateName;
     }
 
-    public function loadPartial(string $templateName): Template
+    public function loadPartial(string $templateName, bool $parseIfMissing = false): Template
     {
         if ($partial = $this->sharedState->partialsCache->get($templateName)) {
             return $partial;
         }
 
-        throw new StandardException(sprintf("The partial '%s' has not be loaded during parsing", $templateName));
+        if (! $parseIfMissing) {
+            throw new StandardException(sprintf("The partial '%s' has not be loaded during parsing", $templateName));
+        }
+
+        $parseContext = $this->environment->newParseContext();
+
+        $template = $parseContext->loadPartial($templateName);
+
+        $this->sharedState->partialsCache->merge($parseContext->getPartialsCache());
+        $this->sharedState->outputs->merge($parseContext->getOutputs());
+
+        return $template;
     }
 
     public function mergePartialsCache(PartialsCache $partialsCache): RenderContext

--- a/src/Tags/Custom/DynamicRenderTag.php
+++ b/src/Tags/Custom/DynamicRenderTag.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Keepsuit\Liquid\Tags\Custom;
+
+use Keepsuit\Liquid\Parse\ExpressionParser;
+use Keepsuit\Liquid\Tags\RenderTag;
+
+/**
+ * @phpstan-import-type Expression from ExpressionParser
+ */
+class DynamicRenderTag extends RenderTag
+{
+    protected function allowDynamicPartials(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Integration/Tags/Custom/DynamicRenderTag.php
+++ b/tests/Integration/Tags/Custom/DynamicRenderTag.php
@@ -1,0 +1,20 @@
+<?php
+
+use Keepsuit\Liquid\EnvironmentFactory;
+use Keepsuit\Liquid\Tests\Stubs\StubFileSystem;
+
+test('dynamically template name', function () {
+    $environment = EnvironmentFactory::new()
+        ->setFilesystem(new StubFileSystem(partials: ['snippet' => 'echo']))
+        ->setRethrowErrors(true)
+        ->build();
+
+    $environment->tagRegistry->register(\Keepsuit\Liquid\Tags\Custom\DynamicRenderTag::class);
+
+    expect($environment->tagRegistry->get('render'))
+        ->toBe(\Keepsuit\Liquid\Tags\Custom\DynamicRenderTag::class);
+
+    $template = $environment->parseString("{% assign name = 'snippet' %}{% render name %}");
+
+    expect($template->render($environment->newRenderContext()))->toBe('echo');
+});


### PR DESCRIPTION
Replace #25 
Fix #24 

This PR adds `DynamicRenderTag` that can be be used as a replacement for `RenderTag` to support rendering partials with dynamic name (the name is not known at parse time, so the partial must be parsed at runtime).