### PR TITLE
Shopify liquid 5.8 compatibility

### DIFF
--- a/src/Extensions/StandardExtension.php
+++ b/src/Extensions/StandardExtension.php
@@ -17,6 +17,7 @@ class StandardExtension extends Extension
             Tags\ContinueTag::class,
             Tags\CycleTag::class,
             Tags\DecrementTag::class,
+            Tags\DocTag::class,
             Tags\EchoTag::class,
             Tags\ForTag::class,
             Tags\IfChanged::class,

--- a/src/Extensions/StandardExtension.php
+++ b/src/Extensions/StandardExtension.php
@@ -24,6 +24,7 @@ class StandardExtension extends Extension
             Tags\IfTag::class,
             Tags\IncrementTag::class,
             Tags\LiquidTag::class,
+            Tags\RawTag::class,
             Tags\RenderTag::class,
             Tags\TableRowTag::class,
             Tags\UnlessTag::class,

--- a/src/Parse/Lexer.php
+++ b/src/Parse/Lexer.php
@@ -119,8 +119,9 @@ class Lexer
         $this->pushToken(TokenType::TextData, $textBeforeToken);
         $this->moveCursor($text.$position[0]);
 
-        switch (rtrim($this->positions[$this->position][0], LexerOptions::WhitespaceTrim->value)) {
+        switch ($this->positions[$this->position][0]) {
             case LexerOptions::TagBlockStart->value:
+            case LexerOptions::TagBlockStart->value.LexerOptions::WhitespaceTrim->value:
                 // {% comment %}
                 if (preg_match(LexerOptions::blockCommentStartRegex(), $this->source, $matches, offset: $this->cursor) === 1) {
                     $this->moveCursor($matches[0]);
@@ -133,6 +134,7 @@ class Lexer
                 $this->currentVarBlockLine = $this->lineNumber;
                 break;
             case LexerOptions::TagVariableStart->value:
+            case LexerOptions::TagVariableStart->value.LexerOptions::WhitespaceTrim->value:
                 $this->pushToken(TokenType::VariableStart);
                 $this->pushState(LexerState::Variable);
                 $this->currentVarBlockLine = $this->lineNumber;

--- a/src/Parse/Lexer.php
+++ b/src/Parse/Lexer.php
@@ -153,7 +153,7 @@ class Lexer
             $this->popState();
 
             // trim?
-            if (trim($matches[0])[0] === LexerOptions::WhitespaceTrim->value) {
+            if ($matches[1][0] === LexerOptions::WhitespaceTrim->value) {
                 $this->trimWhitespaces();
             }
         } else {
@@ -183,7 +183,7 @@ class Lexer
         $this->moveCursor($matches[0]);
 
         // trim?
-        if (trim($matches[0])[0] === LexerOptions::WhitespaceTrim->value) {
+        if ($matches[1][0] === LexerOptions::WhitespaceTrim->value) {
             $this->trimWhitespaces();
         }
 

--- a/src/Parse/Lexer.php
+++ b/src/Parse/Lexer.php
@@ -256,7 +256,7 @@ class Lexer
         }
     }
 
-    private function laxRawBodyTag(string $tag): void
+    protected function laxRawBodyTag(string $tag): void
     {
         if (preg_match(LexerOptions::blockRawBodyTagDataRegex($tag), $this->source, $matches, flags: PREG_OFFSET_CAPTURE, offset: $this->cursor) !== 1) {
             throw SyntaxException::tagBlockNeverClosed($tag);

--- a/src/Parse/LexerOptions.php
+++ b/src/Parse/LexerOptions.php
@@ -53,7 +53,7 @@ enum LexerOptions: string
 
         if ($regex === null) {
             $regex = sprintf(
-                '{\s*(?:%s|%s)}Ax',
+                '{\s*(%s|%s)}Ax',
                 preg_quote(LexerOptions::WhitespaceTrim->value.LexerOptions::TagVariableEnd->value),
                 preg_quote(LexerOptions::TagVariableEnd->value),
             );
@@ -68,7 +68,7 @@ enum LexerOptions: string
 
         if ($regex === null) {
             $regex = sprintf(
-                '{\s*(?:%s|%s)}Ax',
+                '{\s*(%s|%s)}Ax',
                 preg_quote(LexerOptions::WhitespaceTrim->value.LexerOptions::TagBlockEnd->value),
                 preg_quote(LexerOptions::TagBlockEnd->value),
             );

--- a/src/Parse/LexerOptions.php
+++ b/src/Parse/LexerOptions.php
@@ -33,21 +33,6 @@ enum LexerOptions: string
         return $regex;
     }
 
-    public static function commentBlockRegex(): string
-    {
-        static $regex;
-
-        if ($regex === null) {
-            $regex = sprintf(
-                "{\s*comment\s*(?:%s|%s')}Asx",
-                preg_quote(LexerOptions::WhitespaceTrim->value.LexerOptions::TagBlockEnd->value),
-                preg_quote(LexerOptions::TagBlockEnd->value),
-            );
-        }
-
-        return $regex;
-    }
-
     public static function variableEndRegex(): string
     {
         static $regex;
@@ -71,6 +56,24 @@ enum LexerOptions: string
             $regex = sprintf(
                 '{\s*(?:%s|%s)}Ax',
                 preg_quote(LexerOptions::WhitespaceTrim->value.LexerOptions::TagBlockEnd->value),
+                preg_quote(LexerOptions::TagBlockEnd->value),
+            );
+        }
+
+        return $regex;
+    }
+
+    public static function blockRawBodyTagDataRegex(string $tag): string
+    {
+        static $regex;
+
+        if ($regex === null) {
+            $regex = sprintf(
+                '{%s(%s)?\s*end%s\s*(%s)?%s}sx',
+                preg_quote(LexerOptions::TagBlockStart->value),
+                LexerOptions::WhitespaceTrim->value,
+                preg_quote($tag),
+                LexerOptions::WhitespaceTrim->value,
                 preg_quote(LexerOptions::TagBlockEnd->value),
             );
         }

--- a/src/Parse/LexerOptions.php
+++ b/src/Parse/LexerOptions.php
@@ -17,15 +17,29 @@ enum LexerOptions: string
 
     case WhitespaceTrim = '-';
 
-    public static function tokenStartRegex(): string
+    public static function blockStartRegex(): string
     {
         static $regex;
 
         if ($regex === null) {
             $regex = sprintf(
-                '{(%s|%s)(%s)?}sx',
-                preg_quote(LexerOptions::TagVariableStart->value),
+                '{(%s%s?)}sx',
                 preg_quote(LexerOptions::TagBlockStart->value),
+                preg_quote(LexerOptions::WhitespaceTrim->value)
+            );
+        }
+
+        return $regex;
+    }
+
+    public static function variableStartRegex(): string
+    {
+        static $regex;
+
+        if ($regex === null) {
+            $regex = sprintf(
+                '{(%s%s?)}sx',
+                preg_quote(LexerOptions::TagVariableStart->value),
                 preg_quote(LexerOptions::WhitespaceTrim->value)
             );
         }
@@ -65,11 +79,11 @@ enum LexerOptions: string
 
     public static function blockRawBodyTagDataRegex(string $tag): string
     {
-        static $regex;
+        static $regex = [];
 
-        if ($regex === null) {
-            $regex = sprintf(
-                '{%s(%s)?\s*end%s\s*(%s)?%s}sx',
+        if (($regex[$tag] ?? null) === null) {
+            $regex[$tag] = sprintf(
+                '{(%s%s?)\s*end%s\s*(%s?%s)}sx',
                 preg_quote(LexerOptions::TagBlockStart->value),
                 LexerOptions::WhitespaceTrim->value,
                 preg_quote($tag),
@@ -78,39 +92,7 @@ enum LexerOptions: string
             );
         }
 
-        return $regex;
-    }
-
-    public static function blockRawStartRegex(): string
-    {
-        static $regex;
-
-        if ($regex === null) {
-            $regex = sprintf(
-                '{\s*raw\s*(?:%s|%s)}Ax',
-                preg_quote(LexerOptions::WhitespaceTrim->value.LexerOptions::TagBlockEnd->value),
-                preg_quote(LexerOptions::TagBlockEnd->value),
-            );
-        }
-
-        return $regex;
-    }
-
-    public static function blockRawDataRegex(): string
-    {
-        static $regex;
-
-        if ($regex === null) {
-            $regex = sprintf(
-                '{%s(%s)?\s*endraw\s*(%s)?%s}sx',
-                preg_quote(LexerOptions::TagBlockStart->value),
-                LexerOptions::WhitespaceTrim->value,
-                LexerOptions::WhitespaceTrim->value,
-                preg_quote(LexerOptions::TagBlockEnd->value),
-            );
-        }
-
-        return $regex;
+        return $regex[$tag];
     }
 
     public static function blockCommentStartRegex(): string

--- a/src/TagBlock.php
+++ b/src/TagBlock.php
@@ -20,4 +20,9 @@ abstract class TagBlock extends Tag implements HasParseTreeVisitorChildren
     {
         return [];
     }
+
+    public static function hasRawBody(): bool
+    {
+        return false;
+    }
 }

--- a/src/Tags/DocTag.php
+++ b/src/Tags/DocTag.php
@@ -11,7 +11,7 @@ use Keepsuit\Liquid\TagBlock;
 
 class DocTag extends TagBlock
 {
-    public readonly Raw $body;
+    protected Raw $body;
 
     public static function tagName(): string
     {
@@ -53,5 +53,10 @@ class DocTag extends TagBlock
         if (preg_match('/{%-?\s*doc\s*-?%}/', $this->body->value) === 1) {
             throw new SyntaxException('Nested doc tags are not allowed');
         }
+    }
+
+    public function getBody(): Raw
+    {
+        return $this->body;
     }
 }

--- a/src/Tags/DocTag.php
+++ b/src/Tags/DocTag.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Keepsuit\Liquid\Tags;
+
+use Keepsuit\Liquid\Exceptions\SyntaxException;
+use Keepsuit\Liquid\Nodes\BodyNode;
+use Keepsuit\Liquid\Nodes\Raw;
+use Keepsuit\Liquid\Parse\TagParseContext;
+use Keepsuit\Liquid\Render\RenderContext;
+use Keepsuit\Liquid\TagBlock;
+
+class DocTag extends TagBlock
+{
+    protected Raw $body;
+
+    public static function tagName(): string
+    {
+        return 'doc';
+    }
+
+    public static function hasRawBody(): bool
+    {
+        return true;
+    }
+
+    public function parse(TagParseContext $context): static
+    {
+        $context->params->assertEnd();
+
+        assert($context->body instanceof BodyNode);
+
+        $body = $context->body->children()[0] ?? null;
+        $this->body = match (true) {
+            $body instanceof Raw => $body,
+            default => throw new SyntaxException('doc tag must have a single raw body'),
+        };
+
+        $this->ensureNoNestedDocTags();
+
+        return $this;
+    }
+
+    public function render(RenderContext $context): string
+    {
+        return '';
+    }
+
+    /**
+     * @throws SyntaxException
+     */
+    protected function ensureNoNestedDocTags(): void
+    {
+        if (preg_match('/{%-?\s*doc\s*-?%}/', $this->body->value) === 1) {
+            throw new SyntaxException('Nested doc tags are not allowed');
+        }
+    }
+}

--- a/src/Tags/DocTag.php
+++ b/src/Tags/DocTag.php
@@ -11,7 +11,7 @@ use Keepsuit\Liquid\TagBlock;
 
 class DocTag extends TagBlock
 {
-    protected Raw $body;
+    public readonly Raw $body;
 
     public static function tagName(): string
     {

--- a/src/Tags/RawTag.php
+++ b/src/Tags/RawTag.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Keepsuit\Liquid\Tags;
+
+use Keepsuit\Liquid\Exceptions\SyntaxException;
+use Keepsuit\Liquid\Nodes\BodyNode;
+use Keepsuit\Liquid\Nodes\Raw;
+use Keepsuit\Liquid\Parse\TagParseContext;
+use Keepsuit\Liquid\Render\RenderContext;
+use Keepsuit\Liquid\TagBlock;
+
+class RawTag extends TagBlock
+{
+    protected Raw $body;
+
+    public static function tagName(): string
+    {
+        return 'raw';
+    }
+
+    public static function hasRawBody(): bool
+    {
+        return true;
+    }
+
+    public function parse(TagParseContext $context): static
+    {
+        $context->params->assertEnd();
+
+        assert($context->body instanceof BodyNode);
+
+        $body = $context->body->children()[0] ?? null;
+        $this->body = match (true) {
+            $body instanceof Raw => $body,
+            default => throw new SyntaxException('raw tag must have a single raw body'),
+        };
+
+        return $this;
+    }
+
+    public function render(RenderContext $context): string
+    {
+        return $this->body->render($context);
+    }
+}

--- a/src/Tags/RawTag.php
+++ b/src/Tags/RawTag.php
@@ -42,4 +42,9 @@ class RawTag extends TagBlock
     {
         return $this->body->render($context);
     }
+
+    public function getBody(): Raw
+    {
+        return $this->body;
+    }
 }

--- a/tests/Integration/Tags/DocTagTest.php
+++ b/tests/Integration/Tags/DocTagTest.php
@@ -140,3 +140,23 @@ test('doc tag delimiter handling', function () {
     assertMatchSyntaxError("Liquid syntax error (line 1): 'doc' tag was never closed", '{% doc %}123{% enddoc xyz %}');
     assertTemplateResult('', "{% doc %}123{% enddoc\n   xyz %}{% enddoc %}");
 });
+
+test('access doc tag body', function () {
+    $content = <<<'EOF'
+    Renders loading-spinner.
+    @param {string} foo - some foo
+    @param {string} [bar] - optional bar
+    EOF;
+
+    $template = <<<LIQUID
+    {% doc %}$content{% enddoc %}
+    LIQUID;
+
+    $template = parseTemplate($template);
+    $docTag = $template->root->body->children()[0] ?? null;
+
+    expect($docTag)
+        ->toBeInstanceOf(\Keepsuit\Liquid\Tags\DocTag::class)
+        ->getBody()->toBeInstanceOf(\Keepsuit\Liquid\Nodes\Raw::class)
+        ->getBody()->value->toBe($content);
+});

--- a/tests/Integration/Tags/DocTagTest.php
+++ b/tests/Integration/Tags/DocTagTest.php
@@ -1,0 +1,142 @@
+<?php
+
+test('doc tag', function () {
+    $template = <<<'LIQUID'
+    {% doc %}
+        Renders loading-spinner.
+        @param {string} foo - some foo
+        @param {string} [bar] - optional bar
+        @example
+        {% render 'loading-spinner', foo: 'foo' %}
+        {% render 'loading-spinner', foo: 'foo', bar: 'bar' %}
+    {% enddoc %}
+    LIQUID;
+
+    assertTemplateResult('', $template);
+});
+
+test('doc tag does not support extra arguments', function () {
+    $template = <<<'LIQUID'
+    {% doc extra %}
+    {% enddoc %}
+    LIQUID;
+
+    assertMatchSyntaxError('Liquid syntax error (line 2): Unexpected token Identifier: "extra"', $template);
+});
+
+test('doc tag must support valid tags', function () {
+    assertMatchSyntaxError("Liquid syntax error (line 1): 'doc' tag was never closed", '{% doc %} foo');
+    assertMatchSyntaxError('Liquid syntax error (line 1): Unexpected character }', '{% doc } foo {% enddoc %}');
+    assertMatchSyntaxError('Liquid syntax error (line 1): Unexpected character }', '{% doc } foo %}{% enddoc %}');
+});
+
+test('doc tag ignores liquid nodes', function () {
+    $template = <<<'LIQUID'
+    {% doc %}
+        {% if true %}
+        {% if ... %}
+        {%- for ? -%}
+        {% while true %}
+        {%
+            unless if
+        %}
+        {% endcase %}
+    {% enddoc %}
+    LIQUID;
+
+    assertTemplateResult('', $template);
+});
+
+test('doc tag ignores unclosed liquid tags', function () {
+    $template = <<<'LIQUID'
+    {% doc %}
+        {% if true %}
+    {% enddoc %}
+    LIQUID;
+
+    assertTemplateResult('', $template);
+});
+
+test('doc tag does not allow nested docs', function () {
+    $template = <<<'LIQUID'
+    {% doc %}
+        {% doc %}
+            {% doc %}
+    {% enddoc %}
+    LIQUID;
+
+    assertMatchSyntaxError('Liquid syntax error (line 4): Nested doc tags are not allowed', $template);
+});
+
+test('doc tag ignores nested raw tags', function () {
+    $template = <<<'LIQUID'
+    {% doc %}
+        {% raw %}
+    {% enddoc %}
+    LIQUID;
+
+    assertTemplateResult('', $template);
+});
+
+test('doc tag ignores unclosed assign', function () {
+    $template = <<<'LIQUID'
+    {% doc %}
+        {% assign foo = "1"
+    {% enddoc %}
+    LIQUID;
+
+    assertTemplateResult('', $template);
+});
+
+test('doc tag ignores malformed syntax', function () {
+    $template = <<<'LIQUID'
+    {% doc %}
+        {% {{
+    {%- enddoc %}
+    LIQUID;
+
+    assertTemplateResult('', $template);
+});
+
+test('doc tag preserves error line numbers', function () {
+    $template = <<<'LIQUID'
+    {% doc %}
+        {% if true %}
+    {% enddoc %}
+    {{ errors.standard_error }}
+    LIQUID;
+
+    $expected = <<<'TEXT'
+
+    Liquid error (line 4): Standard error
+    TEXT;
+
+    assertTemplateResult(
+        $expected,
+        $template,
+        ['errors' => new \Keepsuit\Liquid\Tests\Stubs\ErrorDrop],
+        renderErrors: true
+    );
+});
+
+test('doc tag whitespace control', function () {
+    assertTemplateResult('Hello!', '      {%- doc -%}123{%- enddoc -%}Hello!');
+    assertTemplateResult('Hello!', '{%- doc -%}123{%- enddoc -%}     Hello!');
+    assertTemplateResult('Hello!', '      {%- doc -%}123{%- enddoc -%}     Hello!');
+    assertTemplateResult('Hello!', <<<'LIQUID'
+      {%- doc %}Whitespace control!{% enddoc -%}
+      Hello!
+    LIQUID);
+});
+
+test('doc tag delimiter handling', function () {
+    assertTemplateResult('', <<<'LIQUID'
+    {% if true -%}
+        {% doc %}
+            {% docEXTRA %}wut{% enddocEXTRA %}xyz
+        {% enddoc %}
+    {%- endif %}
+    LIQUID);
+    assertMatchSyntaxError("Liquid syntax error (line 1): 'doc' tag was never closed", '{% doc %}123{% enddoc xyz %}');
+    assertTemplateResult('', "{% doc %}123{% enddoc\n   xyz %}{% enddoc %}");
+});

--- a/tests/Integration/Tags/InlineCommentTagTest.php
+++ b/tests/Integration/Tags/InlineCommentTagTest.php
@@ -51,5 +51,5 @@ test('inline comment can be written on multiple lines inside liquid tag', functi
 });
 
 test('inline comment does not support nested tags', function () {
-    assertMatchSyntaxError('Liquid syntax error (line 1): Unexpected token type: %}', "{%- # {% echo 'hello world' %} -%}");
+    assertTemplateResult(' -%}', "{%- # {% echo 'hello world' %} -%}");
 });

--- a/tests/Integration/Tags/RawTagTest.php
+++ b/tests/Integration/Tags/RawTagTest.php
@@ -9,8 +9,9 @@ test('tag in raw', function () {
 
 test('output in raw', function () {
     assertTemplateResult('>{{ test }}<', '> {%- raw -%}{{ test }}{%- endraw -%} <');
-    assertTemplateResult('> inner  <', '> {%- raw -%} inner {%- endraw %} <');
-    assertTemplateResult('> inner <', '> {%- raw -%} inner {%- endraw -%} <');
+    assertTemplateResult('>inner <', '> {%- raw -%} inner {%- endraw %} <');
+    assertTemplateResult('>inner<', '> {%- raw -%} inner {%- endraw -%} <');
+    assertTemplateResult('{Hello}', '{% raw %}{{% endraw %}Hello{% raw %}}{% endraw %}');
 });
 
 test('open tag in raw', function () {

--- a/tests/Integration/Tags/RawTagTest.php
+++ b/tests/Integration/Tags/RawTagTest.php
@@ -31,3 +31,25 @@ test('invalid  raw', function () {
     assertMatchSyntaxError('Liquid syntax error (line 1): Unexpected character }', '{% raw } foo {% endraw %}');
     assertMatchSyntaxError('Liquid syntax error (line 1): Unexpected character }', '{% raw } foo %}{% endraw %}');
 });
+
+test('access raw tag body', function () {
+    $content = <<<'EOF'
+    {% if true %}
+    true
+    {% else %}
+    false
+    {% endif %}
+    EOF;
+
+    $template = <<<LIQUID
+    {% raw %}$content{% endraw %}
+    LIQUID;
+
+    $template = parseTemplate($template);
+    $rawTag = $template->root->body->children()[0] ?? null;
+
+    expect($rawTag)
+        ->toBeInstanceOf(\Keepsuit\Liquid\Tags\RawTag::class)
+        ->getBody()->toBeInstanceOf(\Keepsuit\Liquid\Nodes\Raw::class)
+        ->getBody()->value->toBe($content);
+});

--- a/tests/Unit/BlockTest.php
+++ b/tests/Unit/BlockTest.php
@@ -2,6 +2,7 @@
 
 use Keepsuit\Liquid\Nodes\Text;
 use Keepsuit\Liquid\Nodes\Variable;
+use Keepsuit\Liquid\Tags\DocTag;
 use Keepsuit\Liquid\Tags\IfTag;
 
 test('blankspace', function () {
@@ -64,5 +65,15 @@ test('with block', function () {
         ->{1}->toBeInstanceOf(IfTag::class)
         ->{1}->children()->{0}->children()->toHaveCount(1)
         ->{1}->children()->{0}->children()->{0}->toBeInstanceOf(Text::class)
+        ->{2}->toBeInstanceOf(Text::class);
+});
+
+test('doc tag with block', function () {
+    $template = parseTemplate("  {% doc %} {% enddoc %} ");
+
+    expect($template->root->body->children())
+        ->toHaveCount(3)
+        ->{0}->toBeInstanceOf(Text::class)
+        ->{1}->toBeInstanceOf(DocTag::class)
         ->{2}->toBeInstanceOf(Text::class);
 });

--- a/tests/Unit/BlockTest.php
+++ b/tests/Unit/BlockTest.php
@@ -69,7 +69,7 @@ test('with block', function () {
 });
 
 test('doc tag with block', function () {
-    $template = parseTemplate("  {% doc %} {% enddoc %} ");
+    $template = parseTemplate('  {% doc %} {% enddoc %} ');
 
     expect($template->root->body->children())
         ->toHaveCount(3)

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -15,7 +15,7 @@ test('default environment has standard tags registered', function () {
 
     $tags = $env->tagRegistry->all();
 
-    expect($tags)->toHaveCount(17)
+    expect($tags)->toHaveCount(18)
         ->toHaveKey('assign')
         ->toHaveKey('break')
         ->toHaveKey('capture')
@@ -29,6 +29,7 @@ test('default environment has standard tags registered', function () {
         ->toHaveKey('if')
         ->toHaveKey('increment')
         ->toHaveKey('liquid')
+        ->toHaveKey('raw')
         ->toHaveKey('render')
         ->toHaveKey('tablerow')
         ->toHaveKey('unless');

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -15,13 +15,14 @@ test('default environment has standard tags registered', function () {
 
     $tags = $env->tagRegistry->all();
 
-    expect($tags)->toHaveCount(16)
+    expect($tags)->toHaveCount(17)
         ->toHaveKey('assign')
         ->toHaveKey('break')
         ->toHaveKey('capture')
         ->toHaveKey('case')
         ->toHaveKey('cycle')
         ->toHaveKey('decrement')
+        ->toHaveKey('doc')
         ->toHaveKey('echo')
         ->toHaveKey('for')
         ->toHaveKey('ifchanged')

--- a/tests/Unit/ParseTreeVisitorTest.php
+++ b/tests/Unit/ParseTreeVisitorTest.php
@@ -152,6 +152,10 @@ test('preserve tree structure', function () {
         ]);
 });
 
+test('doc', function () {
+    expect(visit('{% doc %}{{ test }}{% enddoc %}'))->toBe([]);
+});
+
 function traversal(string $source): ParseTreeVisitor
 {
     $environment = EnvironmentFactory::new()


### PR DESCRIPTION
- Added support for custom tags with raw body
- Added `doc` tag
- Rewrite `raw` tag as `TagBlock` instead of a `Raw` node