### PR TITLE
Add Shopify Liquid v5.13 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,6 @@
 
 All notable changes to `liquid` will be documented in this file.
 
-## v0.11.0 - 2026-07-10
-
-### What's Changed
-
-* Add Shopify Liquid 5.13 compatibility by @cappuc
-  * Add `self` drop: templates can now use `{{ self.var }}`, `{{ self[key] }}`, and pass `self` across `render` boundaries. The implicit `self` in a partial is isolated to that partial's scope; an explicit `self: self` argument retains the caller's context.
-  * Parser hardening: `assign`, `capture`, `increment`, and `decrement` now reject dotted or bracketed targets (e.g. `{% assign foo.bar = "x" %}`) at parse time.
-
-**Full Changelog**: https://github.com/keepsuit/php-liquid/compare/v0.10.0...v0.11.0
-
 ## v0.10.0 - 2026-06-13
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `liquid` will be documented in this file.
 
+## v0.11.0 - 2026-07-10
+
+### What's Changed
+
+* Add Shopify Liquid 5.13 compatibility by @cappuc
+  * Add `self` drop: templates can now use `{{ self.var }}`, `{{ self[key] }}`, and pass `self` across `render` boundaries. The implicit `self` in a partial is isolated to that partial's scope; an explicit `self: self` argument retains the caller's context.
+  * Parser hardening: `assign`, `capture`, `increment`, and `decrement` now reject dotted or bracketed targets (e.g. `{% assign foo.bar = "x" %}`) at parse time.
+
+**Full Changelog**: https://github.com/keepsuit/php-liquid/compare/v0.10.0...v0.11.0
+
 ## v0.10.0 - 2026-06-13
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Liquid is a template engine with interesting advantages:
 
 |  PHP Liquid | Shopify Liquid |
 |------------:|---------------:|
+|       v0.11 |          v5.13 |
 |       v0.10 |          v5.12 |
 |        v0.9 |           v5.8 |
 |        v0.8 |           v5.7 |

--- a/src/Drops/SelfDrop.php
+++ b/src/Drops/SelfDrop.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Keepsuit\Liquid\Drops;
+
+use Keepsuit\Liquid\Render\RenderContext;
+
+/**
+ * Proxy object that resolves property lookups through the current render context scope chain.
+ * Intentionally does not implement IsContextAware: a SelfDrop passed across a render boundary
+ * must keep its original context rather than being rebound to the partial's context.
+ */
+final class SelfDrop
+{
+    public function __construct(
+        private readonly RenderContext $context
+    ) {}
+
+    public function __get(string $name): mixed
+    {
+        $variables = $this->context->findVariables($name);
+
+        return $variables[0] ?? null;
+    }
+
+    public function __isset(string $name): bool
+    {
+        return true;
+    }
+
+    public function __toString(): string
+    {
+        return '';
+    }
+}

--- a/src/Drops/SelfDrop.php
+++ b/src/Drops/SelfDrop.php
@@ -24,7 +24,9 @@ final class SelfDrop
 
     public function __isset(string $name): bool
     {
-        return true;
+        $variables = $this->context->findVariables($name);
+
+        return $variables !== [];
     }
 
     public function __toString(): string

--- a/src/Exceptions/SyntaxException.php
+++ b/src/Exceptions/SyntaxException.php
@@ -79,6 +79,21 @@ class SyntaxException extends LiquidException
         ));
     }
 
+    public static function expectedSimpleVariable(): SyntaxException
+    {
+        return new SyntaxException('Expected a simple variable name');
+    }
+
+    public static function tagSyntaxException(string $tagName, string $validSyntax, SyntaxException|string $original): SyntaxException
+    {
+        $originalMessage = $original instanceof SyntaxException ? $original->getMessage() : $original;
+        $previous = $original instanceof SyntaxException ? $original : null;
+        $exception = new SyntaxException($originalMessage.' - Valid syntax: '.$validSyntax, 0, E_ERROR, '', 0, $previous);
+        $exception->tagName = $tagName;
+
+        return $exception;
+    }
+
     protected function messagePrefix(): string
     {
         return 'Liquid syntax error';

--- a/src/Exceptions/SyntaxException.php
+++ b/src/Exceptions/SyntaxException.php
@@ -79,16 +79,9 @@ class SyntaxException extends LiquidException
         ));
     }
 
-    public static function expectedSimpleVariable(): SyntaxException
+    public static function tagSyntaxException(string $tagName, string $validSyntax, SyntaxException $original): SyntaxException
     {
-        return new SyntaxException('Expected a simple variable name');
-    }
-
-    public static function tagSyntaxException(string $tagName, string $validSyntax, SyntaxException|string $original): SyntaxException
-    {
-        $originalMessage = $original instanceof SyntaxException ? $original->getMessage() : $original;
-        $previous = $original instanceof SyntaxException ? $original : null;
-        $exception = new SyntaxException($originalMessage.' - Valid syntax: '.$validSyntax, 0, E_ERROR, '', 0, $previous);
+        $exception = new SyntaxException(sprintf('%s - Valid syntax: %s', $original->getMessage(), $validSyntax), previous: $original);
         $exception->tagName = $tagName;
 
         return $exception;

--- a/src/Parse/TokenStream.php
+++ b/src/Parse/TokenStream.php
@@ -5,7 +5,6 @@ namespace Keepsuit\Liquid\Parse;
 use Closure;
 use Keepsuit\Liquid\Exceptions\SyntaxException;
 use Keepsuit\Liquid\Nodes\Variable;
-use Keepsuit\Liquid\Nodes\VariableLookup;
 
 /**
  * @phpstan-import-type Argument from ArgumentParser
@@ -93,8 +92,6 @@ class TokenStream
 
     /**
      * @throws SyntaxException
-     *
-     * @phpstan-impure
      */
     public function id(string $identifier): Token
     {
@@ -149,13 +146,7 @@ class TokenStream
      */
     public function simpleVariableName(): string
     {
-        $expression = $this->expression();
-
-        if ($expression instanceof VariableLookup && $expression->lookups === []) {
-            return $expression->name;
-        }
-
-        throw SyntaxException::expectedSimpleVariable();
+        return $this->consume(TokenType::Identifier)->data;
     }
 
     /**

--- a/src/Parse/TokenStream.php
+++ b/src/Parse/TokenStream.php
@@ -5,6 +5,7 @@ namespace Keepsuit\Liquid\Parse;
 use Closure;
 use Keepsuit\Liquid\Exceptions\SyntaxException;
 use Keepsuit\Liquid\Nodes\Variable;
+use Keepsuit\Liquid\Nodes\VariableLookup;
 
 /**
  * @phpstan-import-type Argument from ArgumentParser
@@ -141,6 +142,20 @@ class TokenStream
     public function expression(): mixed
     {
         return $this->expressionParser->parseExpression();
+    }
+
+    /**
+     * @throws SyntaxException
+     */
+    public function simpleVariableName(string $error): string
+    {
+        $expression = $this->expression();
+
+        if ($expression instanceof VariableLookup && $expression->lookups === []) {
+            return $expression->name;
+        }
+
+        throw new SyntaxException($error);
     }
 
     /**

--- a/src/Parse/TokenStream.php
+++ b/src/Parse/TokenStream.php
@@ -147,7 +147,7 @@ class TokenStream
     /**
      * @throws SyntaxException
      */
-    public function simpleVariableName(string $error): string
+    public function simpleVariableName(): string
     {
         $expression = $this->expression();
 
@@ -155,7 +155,7 @@ class TokenStream
             return $expression->name;
         }
 
-        throw new SyntaxException($error);
+        throw SyntaxException::expectedSimpleVariable();
     }
 
     /**

--- a/src/Render/RenderContext.php
+++ b/src/Render/RenderContext.php
@@ -9,6 +9,7 @@ use Keepsuit\Liquid\Contracts\IsContextAware;
 use Keepsuit\Liquid\Contracts\LiquidErrorHandler;
 use Keepsuit\Liquid\Contracts\MapsToLiquid;
 use Keepsuit\Liquid\Drop;
+use Keepsuit\Liquid\Drops\SelfDrop;
 use Keepsuit\Liquid\Environment;
 use Keepsuit\Liquid\ErrorHandlers\RethrowErrorHandler;
 use Keepsuit\Liquid\Exceptions\ArithmeticException;
@@ -58,6 +59,8 @@ final class RenderContext
      * @var array<Interrupt>
      */
     protected array $interrupts = [];
+
+    private ?SelfDrop $selfDrop = null;
 
     public function __construct(
         /**
@@ -183,6 +186,13 @@ final class RenderContext
 
         $variables = array_values(array_filter($variables, fn (mixed $value) => ! $value instanceof MissingValue));
 
+        // Inject the implicit self drop only when no value (including explicit null) was found.
+        // An explicit `self = nil` leaves [null] in $variables, so the fallback is skipped,
+        // correctly distinguishing defined-null from undefined.
+        if ($variables === [] && $key === 'self') {
+            return [$this->getSelfDrop()];
+        }
+
         foreach ($variables as $variable) {
             if ($variable instanceof IsContextAware) {
                 $variable->setContext($this);
@@ -190,6 +200,11 @@ final class RenderContext
         }
 
         return $variables;
+    }
+
+    public function getSelfDrop(): SelfDrop
+    {
+        return $this->selfDrop ??= new SelfDrop($this);
     }
 
     public function internalContextLookup(mixed $scope, int|string $key): mixed

--- a/src/Tags/AssignTag.php
+++ b/src/Tags/AssignTag.php
@@ -37,7 +37,7 @@ class AssignTag extends Tag implements HasParseTreeVisitorChildren
 
             $context->params->assertEnd();
         } catch (SyntaxException $e) {
-            throw SyntaxException::tagSyntaxException('assign', 'assign [var] = [source]', $e);
+            throw SyntaxException::tagSyntaxException('assign', 'assign <var> = <source>', $e);
         }
 
         return $this;

--- a/src/Tags/AssignTag.php
+++ b/src/Tags/AssignTag.php
@@ -5,7 +5,6 @@ namespace Keepsuit\Liquid\Tags;
 use Keepsuit\Liquid\Contracts\HasParseTreeVisitorChildren;
 use Keepsuit\Liquid\Exceptions\SyntaxException;
 use Keepsuit\Liquid\Nodes\Variable;
-use Keepsuit\Liquid\Nodes\VariableLookup;
 use Keepsuit\Liquid\Parse\ExpressionParser;
 use Keepsuit\Liquid\Parse\TagParseContext;
 use Keepsuit\Liquid\Parse\TokenType;
@@ -32,11 +31,7 @@ class AssignTag extends Tag implements HasParseTreeVisitorChildren
     public function parse(TagParseContext $context): static
     {
         try {
-            $to = $context->params->expression();
-            $this->to = match (true) {
-                $to instanceof VariableLookup && $to->lookups === [] => $to->name,
-                default => throw new SyntaxException(self::SYNTAX_ERROR),
-            };
+            $this->to = $context->params->simpleVariableName(self::SYNTAX_ERROR);
 
             $context->params->consume(TokenType::Equals);
 

--- a/src/Tags/AssignTag.php
+++ b/src/Tags/AssignTag.php
@@ -34,7 +34,7 @@ class AssignTag extends Tag implements HasParseTreeVisitorChildren
         try {
             $to = $context->params->expression();
             $this->to = match (true) {
-                $to instanceof VariableLookup, is_string($to) => (string) $to,
+                $to instanceof VariableLookup && $to->lookups === [] => $to->name,
                 default => throw new SyntaxException(self::SYNTAX_ERROR),
             };
 

--- a/src/Tags/AssignTag.php
+++ b/src/Tags/AssignTag.php
@@ -17,8 +17,6 @@ use Keepsuit\Liquid\Tag;
  */
 class AssignTag extends Tag implements HasParseTreeVisitorChildren
 {
-    protected const SYNTAX_ERROR = "Syntax Error in 'assign' - Valid syntax: assign [var] = [source]";
-
     protected string $to;
 
     protected Variable $from;
@@ -31,7 +29,7 @@ class AssignTag extends Tag implements HasParseTreeVisitorChildren
     public function parse(TagParseContext $context): static
     {
         try {
-            $this->to = $context->params->simpleVariableName(self::SYNTAX_ERROR);
+            $this->to = $context->params->simpleVariableName();
 
             $context->params->consume(TokenType::Equals);
 
@@ -39,7 +37,7 @@ class AssignTag extends Tag implements HasParseTreeVisitorChildren
 
             $context->params->assertEnd();
         } catch (SyntaxException $e) {
-            throw new SyntaxException(self::SYNTAX_ERROR);
+            throw SyntaxException::tagSyntaxException('assign', 'assign [var] = [source]', $e);
         }
 
         return $this;

--- a/src/Tags/BreakTag.php
+++ b/src/Tags/BreakTag.php
@@ -2,6 +2,7 @@
 
 namespace Keepsuit\Liquid\Tags;
 
+use Keepsuit\Liquid\Exceptions\SyntaxException;
 use Keepsuit\Liquid\Interrupts\BreakInterrupt;
 use Keepsuit\Liquid\Parse\TagParseContext;
 use Keepsuit\Liquid\Render\RenderContext;
@@ -16,7 +17,11 @@ class BreakTag extends Tag
 
     public function parse(TagParseContext $context): static
     {
-        $context->params->assertEnd();
+        try {
+            $context->params->assertEnd();
+        } catch (SyntaxException $e) {
+            throw SyntaxException::tagSyntaxException(static::tagName(), 'break', $e);
+        }
 
         return $this;
     }

--- a/src/Tags/CaptureTag.php
+++ b/src/Tags/CaptureTag.php
@@ -2,9 +2,7 @@
 
 namespace Keepsuit\Liquid\Tags;
 
-use Keepsuit\Liquid\Exceptions\SyntaxException;
 use Keepsuit\Liquid\Nodes\BodyNode;
-use Keepsuit\Liquid\Nodes\VariableLookup;
 use Keepsuit\Liquid\Parse\TagParseContext;
 use Keepsuit\Liquid\Render\RenderContext;
 use Keepsuit\Liquid\TagBlock;
@@ -23,12 +21,7 @@ class CaptureTag extends TagBlock
 
         $this->body = $context->body;
 
-        $to = $context->params->expression();
-        $this->to = match (true) {
-            $to instanceof VariableLookup && $to->lookups === [] => $to->name,
-            is_string($to) => $to,
-            default => throw new SyntaxException(self::SYNTAX_ERROR),
-        };
+        $this->to = $context->params->simpleVariableName(self::SYNTAX_ERROR);
 
         $context->params->assertEnd();
 

--- a/src/Tags/CaptureTag.php
+++ b/src/Tags/CaptureTag.php
@@ -2,6 +2,7 @@
 
 namespace Keepsuit\Liquid\Tags;
 
+use Keepsuit\Liquid\Exceptions\SyntaxException;
 use Keepsuit\Liquid\Nodes\BodyNode;
 use Keepsuit\Liquid\Parse\TagParseContext;
 use Keepsuit\Liquid\Render\RenderContext;
@@ -9,8 +10,6 @@ use Keepsuit\Liquid\TagBlock;
 
 class CaptureTag extends TagBlock
 {
-    protected const SYNTAX_ERROR = "Syntax Error in 'capture' - Valid syntax: capture [var]";
-
     protected string $to;
 
     protected BodyNode $body;
@@ -21,9 +20,13 @@ class CaptureTag extends TagBlock
 
         $this->body = $context->body;
 
-        $this->to = $context->params->simpleVariableName(self::SYNTAX_ERROR);
+        try {
+            $this->to = $context->params->simpleVariableName();
 
-        $context->params->assertEnd();
+            $context->params->assertEnd();
+        } catch (SyntaxException $e) {
+            throw SyntaxException::tagSyntaxException('capture', 'capture [var]', $e);
+        }
 
         return $this;
     }

--- a/src/Tags/CaptureTag.php
+++ b/src/Tags/CaptureTag.php
@@ -25,7 +25,7 @@ class CaptureTag extends TagBlock
 
             $context->params->assertEnd();
         } catch (SyntaxException $e) {
-            throw SyntaxException::tagSyntaxException('capture', 'capture [var]', $e);
+            throw SyntaxException::tagSyntaxException('capture', 'capture <var>', $e);
         }
 
         return $this;

--- a/src/Tags/CaptureTag.php
+++ b/src/Tags/CaptureTag.php
@@ -25,7 +25,8 @@ class CaptureTag extends TagBlock
 
         $to = $context->params->expression();
         $this->to = match (true) {
-            is_string($to), $to instanceof VariableLookup => (string) $to,
+            $to instanceof VariableLookup && $to->lookups === [] => $to->name,
+            is_string($to) => $to,
             default => throw new SyntaxException(self::SYNTAX_ERROR),
         };
 

--- a/src/Tags/CaseTag.php
+++ b/src/Tags/CaseTag.php
@@ -32,11 +32,20 @@ class CaseTag extends TagBlock
 
     public function parse(TagParseContext $context): static
     {
-        if ($context->tag === 'case') {
-            $this->left = $context->params->expression();
-            $context->params->assertEnd();
-        } else {
-            $this->conditions[] = $this->mapBodySectionToCondition($context);
+        try {
+            if ($context->tag === 'case') {
+                $this->left = $context->params->expression();
+                $context->params->assertEnd();
+            } else {
+                $this->conditions[] = $this->mapBodySectionToCondition($context);
+            }
+        } catch (SyntaxException $e) {
+            throw SyntaxException::tagSyntaxException(static::tagName(), match ($context->tag) {
+                'case' => 'case <expression>',
+                'when' => 'when <expression> [, <expression>...]',
+                'else' => 'else',
+                default => ''
+            }, $e);
         }
 
         return $this;

--- a/src/Tags/ContinueTag.php
+++ b/src/Tags/ContinueTag.php
@@ -2,6 +2,7 @@
 
 namespace Keepsuit\Liquid\Tags;
 
+use Keepsuit\Liquid\Exceptions\SyntaxException;
 use Keepsuit\Liquid\Interrupts\ContinueInterrupt;
 use Keepsuit\Liquid\Parse\TagParseContext;
 use Keepsuit\Liquid\Render\RenderContext;
@@ -16,7 +17,11 @@ class ContinueTag extends Tag
 
     public function parse(TagParseContext $context): static
     {
-        $context->params->assertEnd();
+        try {
+            $context->params->assertEnd();
+        } catch (SyntaxException $e) {
+            throw SyntaxException::tagSyntaxException(static::tagName(), 'continue', $e);
+        }
 
         return $this;
     }

--- a/src/Tags/CycleTag.php
+++ b/src/Tags/CycleTag.php
@@ -12,8 +12,6 @@ use Keepsuit\Liquid\Tag;
 
 class CycleTag extends Tag implements HasParseTreeVisitorChildren
 {
-    protected const SYNTAX_ERROR = "Syntax Error in 'cycle' - Valid syntax: cycle [name :] var [, var2, var3 ...]";
-
     /**
      * @var (string|int|float)[]
      */
@@ -28,40 +26,49 @@ class CycleTag extends Tag implements HasParseTreeVisitorChildren
 
     public function parse(TagParseContext $context): static
     {
-        $this->name = null;
-        $this->variables = [];
+        try {
+            $this->name = null;
+            $this->variables = [];
 
-        if ($context->params->look(TokenType::Colon, 1)) {
-            if (! in_array($context->params->current()?->type, [TokenType::String, TokenType::Number, TokenType::Identifier])) {
-                throw new SyntaxException(self::SYNTAX_ERROR);
+            if ($context->params->look(TokenType::Colon, 1)) {
+                $currentToken = $context->params->current();
+
+                $name = $context->params->expression();
+                $this->name = match (true) {
+                    is_string($name), is_numeric($name), $name instanceof VariableLookup => (string) $name,
+                    $currentToken === null => throw SyntaxException::unexpectedEndOfTemplate(),
+                    default => throw SyntaxException::unexpectedToken($currentToken),
+                };
+
+                $context->params->consume(TokenType::Colon);
             }
 
-            $name = $context->params->expression();
-            $this->name = match (true) {
-                is_string($name), is_numeric($name), $name instanceof VariableLookup => (string) $name,
-                default => throw new SyntaxException(self::SYNTAX_ERROR),
-            };
+            do {
+                $currentToken = $context->params->current();
 
-            $context->params->consume(TokenType::Colon);
-        }
+                if (! $currentToken) {
+                    throw SyntaxException::unexpectedEndOfTemplate();
+                }
 
-        do {
-            if (! in_array($context->params->current()?->type, [TokenType::String, TokenType::Number])) {
-                throw new SyntaxException(self::SYNTAX_ERROR);
+                if (! in_array($currentToken->type, [TokenType::String, TokenType::Number])) {
+                    throw SyntaxException::unexpectedToken($currentToken);
+                }
+
+                $variable = $context->params->expression();
+                $this->variables[] = match (true) {
+                    is_string($variable), is_numeric($variable) => $variable,
+                    default => throw SyntaxException::unexpectedToken($currentToken)
+                };
+            } while ($context->params->consumeOrFalse(TokenType::Comma));
+
+            if ($this->name === null) {
+                $this->name = json_encode($this->variables, JSON_THROW_ON_ERROR);
             }
 
-            $variable = $context->params->expression();
-            $this->variables[] = match (true) {
-                is_string($variable), is_numeric($variable) => $variable,
-                default => throw new SyntaxException(self::SYNTAX_ERROR),
-            };
-        } while ($context->params->consumeOrFalse(TokenType::Comma));
-
-        if ($this->name === null) {
-            $this->name = json_encode($this->variables, JSON_THROW_ON_ERROR);
+            $context->params->assertEnd();
+        } catch (SyntaxException $e) {
+            throw SyntaxException::tagSyntaxException(static::tagName(), 'cycle [<name>:] <value>[, <value>...]', $e);
         }
-
-        $context->params->assertEnd();
 
         return $this;
     }

--- a/src/Tags/DocTag.php
+++ b/src/Tags/DocTag.php
@@ -25,17 +25,21 @@ class DocTag extends TagBlock
 
     public function parse(TagParseContext $context): static
     {
-        $context->params->assertEnd();
+        try {
+            $context->params->assertEnd();
 
-        assert($context->body instanceof BodyNode);
+            assert($context->body instanceof BodyNode);
 
-        $body = $context->body->children()[0] ?? null;
-        $this->body = match (true) {
-            $body instanceof Raw => $body,
-            default => throw new SyntaxException('doc tag must have a single raw body'),
-        };
+            $body = $context->body->children()[0] ?? null;
+            $this->body = match (true) {
+                $body instanceof Raw => $body,
+                default => throw new SyntaxException('must have a single raw body'),
+            };
 
-        $this->ensureNoNestedDocTags();
+            $this->ensureNoNestedDocTags();
+        } catch (SyntaxException $e) {
+            throw SyntaxException::tagSyntaxException(static::tagName(), 'doc', $e);
+        }
 
         return $this;
     }

--- a/src/Tags/EchoTag.php
+++ b/src/Tags/EchoTag.php
@@ -3,6 +3,7 @@
 namespace Keepsuit\Liquid\Tags;
 
 use Keepsuit\Liquid\Contracts\HasParseTreeVisitorChildren;
+use Keepsuit\Liquid\Exceptions\SyntaxException;
 use Keepsuit\Liquid\Nodes\Variable;
 use Keepsuit\Liquid\Parse\TagParseContext;
 use Keepsuit\Liquid\Render\RenderContext;
@@ -14,9 +15,13 @@ class EchoTag extends Tag implements HasParseTreeVisitorChildren
 
     public function parse(TagParseContext $context): static
     {
-        $this->variable = $context->params->variable();
+        try {
+            $this->variable = $context->params->variable();
 
-        $context->params->assertEnd();
+            $context->params->assertEnd();
+        } catch (SyntaxException $e) {
+            throw SyntaxException::tagSyntaxException(static::tagName(), 'echo <expression>', $e);
+        }
 
         return $this;
     }

--- a/src/Tags/ForTag.php
+++ b/src/Tags/ForTag.php
@@ -54,11 +54,19 @@ class ForTag extends TagBlock implements HasParseTreeVisitorChildren
 
     public function parse(TagParseContext $context): static
     {
-        match ($context->tag) {
-            'for' => $this->parseForBlock($context),
-            'else' => $this->parseElseBlock($context),
-            default => throw new SyntaxException('Invalid tag'),
-        };
+        try {
+            match ($context->tag) {
+                'for' => $this->parseForBlock($context),
+                'else' => $this->parseElseBlock($context),
+                default => throw new SyntaxException('Invalid tag'),
+            };
+        } catch (SyntaxException $e) {
+            throw SyntaxException::tagSyntaxException(static::tagName(), match ($context->tag) {
+                'for' => 'for <var> in <collection> [attributes...]',
+                'else' => 'else',
+                default => ''
+            }, $e);
+        }
 
         return $this;
     }

--- a/src/Tags/IfChanged.php
+++ b/src/Tags/IfChanged.php
@@ -2,6 +2,7 @@
 
 namespace Keepsuit\Liquid\Tags;
 
+use Keepsuit\Liquid\Exceptions\SyntaxException;
 use Keepsuit\Liquid\Nodes\BodyNode;
 use Keepsuit\Liquid\Parse\TagParseContext;
 use Keepsuit\Liquid\Render\RenderContext;
@@ -22,7 +23,11 @@ class IfChanged extends TagBlock
 
         $this->body = $context->body;
 
-        $context->params->assertEnd();
+        try {
+            $context->params->assertEnd();
+        } catch (SyntaxException $e) {
+            throw SyntaxException::tagSyntaxException(static::tagName(), 'ifchanged', $e);
+        }
 
         return $this;
     }

--- a/src/Tags/IfTag.php
+++ b/src/Tags/IfTag.php
@@ -4,6 +4,7 @@ namespace Keepsuit\Liquid\Tags;
 
 use Keepsuit\Liquid\Condition\Condition;
 use Keepsuit\Liquid\Condition\ElseCondition;
+use Keepsuit\Liquid\Exceptions\SyntaxException;
 use Keepsuit\Liquid\Parse\TagParseContext;
 use Keepsuit\Liquid\Parse\TokenType;
 use Keepsuit\Liquid\Render\RenderContext;
@@ -22,7 +23,16 @@ class IfTag extends TagBlock
 
     public function parse(TagParseContext $context): static
     {
-        $this->conditions[] = $this->mapBodySectionToCondition($context);
+        try {
+            $this->conditions[] = $this->mapBodySectionToCondition($context);
+        } catch (SyntaxException $e) {
+            throw SyntaxException::tagSyntaxException(static::tagName(), match ($context->tag) {
+                'if' => 'if <condition>',
+                'elsif' => 'elsif <condition>',
+                'else' => 'else',
+                default => ''
+            }, $e);
+        }
 
         return $this;
     }
@@ -46,6 +56,9 @@ class IfTag extends TagBlock
         return $this->conditions;
     }
 
+    /**
+     * @throws SyntaxException
+     */
     protected function mapBodySectionToCondition(TagParseContext $bodySection): Condition
     {
         $condition = match ($bodySection->tag) {
@@ -85,11 +98,17 @@ class IfTag extends TagBlock
         return in_array($tagName, ['else', 'elsif'], true);
     }
 
+    /**
+     * @throws SyntaxException
+     */
     protected function parseCondition(TagParseContext $bodySection): Condition
     {
         return $this->parseBinaryComparison($bodySection);
     }
 
+    /**
+     * @throws SyntaxException
+     */
     protected function parseBinaryComparison(TagParseContext $bodySection): Condition
     {
         $condition = $this->parseComparison($bodySection);
@@ -104,6 +123,9 @@ class IfTag extends TagBlock
         return $firstCondition;
     }
 
+    /**
+     * @throws SyntaxException
+     */
     protected function parseComparison(TagParseContext $bodySection): Condition
     {
         $a = $bodySection->params->expression();

--- a/src/Tags/IncrementTag.php
+++ b/src/Tags/IncrementTag.php
@@ -2,6 +2,7 @@
 
 namespace Keepsuit\Liquid\Tags;
 
+use Keepsuit\Liquid\Exceptions\SyntaxException;
 use Keepsuit\Liquid\Parse\TagParseContext;
 use Keepsuit\Liquid\Render\RenderContext;
 use Keepsuit\Liquid\Tag;
@@ -17,9 +18,13 @@ class IncrementTag extends Tag
 
     public function parse(TagParseContext $context): static
     {
-        $this->variableName = $context->params->simpleVariableName('Invalid variable name');
+        try {
+            $this->variableName = $context->params->simpleVariableName();
 
-        $context->params->assertEnd();
+            $context->params->assertEnd();
+        } catch (SyntaxException $e) {
+            throw SyntaxException::tagSyntaxException(static::tagName(), sprintf('%s [var]', static::tagName()), $e);
+        }
 
         return $this;
     }

--- a/src/Tags/IncrementTag.php
+++ b/src/Tags/IncrementTag.php
@@ -21,7 +21,7 @@ class IncrementTag extends Tag
     {
         $variableName = $context->params->expression();
         $this->variableName = match (true) {
-            $variableName instanceof VariableLookup || is_string($variableName) => (string) $variableName,
+            $variableName instanceof VariableLookup && $variableName->lookups === [] => $variableName->name,
             default => throw new SyntaxException('Invalid variable name'),
         };
 

--- a/src/Tags/IncrementTag.php
+++ b/src/Tags/IncrementTag.php
@@ -2,8 +2,6 @@
 
 namespace Keepsuit\Liquid\Tags;
 
-use Keepsuit\Liquid\Exceptions\SyntaxException;
-use Keepsuit\Liquid\Nodes\VariableLookup;
 use Keepsuit\Liquid\Parse\TagParseContext;
 use Keepsuit\Liquid\Render\RenderContext;
 use Keepsuit\Liquid\Tag;
@@ -19,11 +17,7 @@ class IncrementTag extends Tag
 
     public function parse(TagParseContext $context): static
     {
-        $variableName = $context->params->expression();
-        $this->variableName = match (true) {
-            $variableName instanceof VariableLookup && $variableName->lookups === [] => $variableName->name,
-            default => throw new SyntaxException('Invalid variable name'),
-        };
+        $this->variableName = $context->params->simpleVariableName('Invalid variable name');
 
         $context->params->assertEnd();
 

--- a/src/Tags/IncrementTag.php
+++ b/src/Tags/IncrementTag.php
@@ -23,7 +23,7 @@ class IncrementTag extends Tag
 
             $context->params->assertEnd();
         } catch (SyntaxException $e) {
-            throw SyntaxException::tagSyntaxException(static::tagName(), sprintf('%s [var]', static::tagName()), $e);
+            throw SyntaxException::tagSyntaxException(static::tagName(), sprintf('%s <var>', static::tagName()), $e);
         }
 
         return $this;

--- a/src/Tags/RawTag.php
+++ b/src/Tags/RawTag.php
@@ -25,15 +25,19 @@ class RawTag extends TagBlock
 
     public function parse(TagParseContext $context): static
     {
-        $context->params->assertEnd();
+        try {
+            $context->params->assertEnd();
 
-        assert($context->body instanceof BodyNode);
+            assert($context->body instanceof BodyNode);
 
-        $body = $context->body->children()[0] ?? null;
-        $this->body = match (true) {
-            $body instanceof Raw => $body,
-            default => throw new SyntaxException('raw tag must have a single raw body'),
-        };
+            $body = $context->body->children()[0] ?? null;
+            $this->body = match (true) {
+                $body instanceof Raw => $body,
+                default => throw new SyntaxException('must have a single raw body'),
+            };
+        } catch (SyntaxException $e) {
+            throw SyntaxException::tagSyntaxException(static::tagName(), 'raw', $e);
+        }
 
         return $this;
     }

--- a/src/Tags/RenderTag.php
+++ b/src/Tags/RenderTag.php
@@ -41,59 +41,63 @@ class RenderTag extends Tag implements CanBeStreamed, HasParseTreeVisitorChildre
 
     public function parse(TagParseContext $context): static
     {
-        $this->isForLoop = false;
-        $this->variableNameExpression = null;
-        $this->attributes = [];
+        try {
+            $this->isForLoop = false;
+            $this->variableNameExpression = null;
+            $this->attributes = [];
 
-        $context->getParseContext()->nested(function () use ($context) {
-            $templateNameExpression = $context->params->expression();
-            $this->templateNameExpression = match (true) {
-                is_string($templateNameExpression) => $templateNameExpression,
-                $this->allowDynamicPartials() && $templateNameExpression instanceof VariableLookup => $templateNameExpression,
-                default => throw new SyntaxException('Template name must be a string'),
-            };
-
-            $context->params->consumeOrFalse(TokenType::Comma);
-
-            if ($context->params->idOrFalse('for')) {
-                $this->isForLoop = true;
-                $this->variableNameExpression = $context->params->expression();
-            } elseif ($context->params->idOrFalse('with')) {
-                $this->variableNameExpression = $context->params->expression();
-            }
-
-            $context->params->consumeOrFalse(TokenType::Comma);
-
-            if ($context->params->idOrFalse('as')) {
-                $aliasName = $context->params->expression();
-                $this->aliasName = match (true) {
-                    is_string($aliasName), $aliasName instanceof VariableLookup => (string) $aliasName,
-                    default => throw new SyntaxException('Alias name must be a valid variable name'),
+            $context->getParseContext()->nested(function () use ($context) {
+                $templateNameExpression = $context->params->expression();
+                $this->templateNameExpression = match (true) {
+                    is_string($templateNameExpression) => $templateNameExpression,
+                    $this->allowDynamicPartials() && $templateNameExpression instanceof VariableLookup => $templateNameExpression,
+                    default => throw new SyntaxException('Template name must be a string'),
                 };
-            } else {
-                $this->aliasName = null;
-            }
 
-            while (! $context->params->isEnd()) {
                 $context->params->consumeOrFalse(TokenType::Comma);
 
-                $attributeName = $context->params->expression();
-                if (! (is_string($attributeName) || $attributeName instanceof VariableLookup)) {
-                    throw new SyntaxException('Attribute name must be a valid variable name');
+                if ($context->params->idOrFalse('for')) {
+                    $this->isForLoop = true;
+                    $this->variableNameExpression = $context->params->expression();
+                } elseif ($context->params->idOrFalse('with')) {
+                    $this->variableNameExpression = $context->params->expression();
                 }
 
-                $context->params->consume(TokenType::Colon);
-                $attributeValue = $context->params->expression();
+                $context->params->consumeOrFalse(TokenType::Comma);
 
-                $this->attributes[(string) $attributeName] = $attributeValue;
-            }
+                if ($context->params->idOrFalse('as')) {
+                    $aliasName = $context->params->expression();
+                    $this->aliasName = match (true) {
+                        is_string($aliasName), $aliasName instanceof VariableLookup => (string) $aliasName,
+                        default => throw new SyntaxException('Alias name must be a valid variable name'),
+                    };
+                } else {
+                    $this->aliasName = null;
+                }
 
-            $context->params->assertEnd();
+                while (! $context->params->isEnd()) {
+                    $context->params->consumeOrFalse(TokenType::Comma);
 
-            if (is_string($this->templateNameExpression)) {
-                $context->getParseContext()->loadPartial($this->templateNameExpression);
-            }
-        });
+                    $attributeName = $context->params->expression();
+                    if (! (is_string($attributeName) || $attributeName instanceof VariableLookup)) {
+                        throw new SyntaxException('Attribute name must be a valid variable name');
+                    }
+
+                    $context->params->consume(TokenType::Colon);
+                    $attributeValue = $context->params->expression();
+
+                    $this->attributes[(string) $attributeName] = $attributeValue;
+                }
+
+                $context->params->assertEnd();
+
+                if (is_string($this->templateNameExpression)) {
+                    $context->getParseContext()->loadPartial($this->templateNameExpression);
+                }
+            });
+        } catch (SyntaxException $e) {
+            throw SyntaxException::tagSyntaxException(static::tagName(), 'render <template> [with|for <expression>] [as <var>] [<attribute>: <value>...]', $e);
+        }
 
         return $this;
     }

--- a/src/Tags/TableRowTag.php
+++ b/src/Tags/TableRowTag.php
@@ -4,6 +4,7 @@ namespace Keepsuit\Liquid\Tags;
 
 use Keepsuit\Liquid\Drops\TableRowLoopDrop;
 use Keepsuit\Liquid\Exceptions\InvalidArgumentException;
+use Keepsuit\Liquid\Exceptions\SyntaxException;
 use Keepsuit\Liquid\Interrupts\BreakInterrupt;
 use Keepsuit\Liquid\Nodes\BodyNode;
 use Keepsuit\Liquid\Nodes\Range;
@@ -31,28 +32,32 @@ class TableRowTag extends TagBlock
 
     public function parse(TagParseContext $context): static
     {
-        assert($context->body !== null);
+        try {
+            assert($context->body !== null);
 
-        $this->body = $context->body;
+            $this->body = $context->body;
 
-        $this->variableName = $context->params->consume(TokenType::Identifier)->data;
-        $context->params->id('in');
-        $this->collectionName = $context->params->expression();
+            $this->variableName = $context->params->consume(TokenType::Identifier)->data;
+            $context->params->id('in');
+            $this->collectionName = $context->params->expression();
 
-        while (true) {
-            $context->params->consumeOrFalse(TokenType::Comma);
+            while (true) {
+                $context->params->consumeOrFalse(TokenType::Comma);
 
-            if ($context->params->isEnd()) {
-                break;
+                if ($context->params->isEnd()) {
+                    break;
+                }
+
+                $attribute = $context->params->consume(TokenType::Identifier)->data;
+                $context->params->consume(TokenType::Colon);
+                $value = $context->params->expression();
+                $this->attributes[$attribute] = $value;
             }
 
-            $attribute = $context->params->consume(TokenType::Identifier)->data;
-            $context->params->consume(TokenType::Colon);
-            $value = $context->params->expression();
-            $this->attributes[$attribute] = $value;
+            $context->params->assertEnd();
+        } catch (SyntaxException $e) {
+            throw SyntaxException::tagSyntaxException(static::tagName(), 'tablerow <var> in <collection> [attributes...]', $e);
         }
-
-        $context->params->assertEnd();
 
         return $this;
     }

--- a/tests/Integration/ExpressionTest.php
+++ b/tests/Integration/ExpressionTest.php
@@ -41,7 +41,7 @@ test('range', function () {
 
 test('bare bracket is not a valid expression', function () {
     assertMatchSyntaxError(
-        "Liquid syntax error (line 1): `[` is not a valid expression",
+        'Liquid syntax error (line 1): `[` is not a valid expression',
         '{{ [foo] }}',
     );
 });

--- a/tests/Integration/ExpressionTest.php
+++ b/tests/Integration/ExpressionTest.php
@@ -39,6 +39,13 @@ test('range', function () {
     );
 });
 
+test('bare bracket is not a valid expression', function () {
+    assertMatchSyntaxError(
+        "Liquid syntax error (line 1): `[` is not a valid expression",
+        '{{ [foo] }}',
+    );
+});
+
 function assertExpressionResult(mixed $expected, string $markup, ...$assigns): void
 {
     $liquid = "{% if expect == $markup %}pass{% else %}got {{ $markup }}{% endif %}";

--- a/tests/Integration/ParsingQuirksTest.php
+++ b/tests/Integration/ParsingQuirksTest.php
@@ -40,7 +40,7 @@ test('throw exception on empty filter', function () {
 
 test('meaningless parens error', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Invalid range syntax, correct syntax is (start..end)',
+        'Liquid syntax error (line 1): Invalid range syntax, correct syntax is (start..end) - Valid syntax: if <condition>',
         "{% if a == 'foo' or (b == 'bar' and c == 'baz') or false %} YES {% endif %}"
     );
 });
@@ -51,7 +51,7 @@ test('unexpected characters', function () {
         '{% if true && false %} YES {% endif %}'
     );
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Unexpected token |: "|"',
+        'Liquid syntax error (line 1): Unexpected token |: "|" - Valid syntax: if <condition>',
         '{% if true || false %} YES {% endif %}'
     );
 });

--- a/tests/Integration/SelfDropTest.php
+++ b/tests/Integration/SelfDropTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Keepsuit\Liquid\EnvironmentFactory;
+
+// US 1: dynamic bracket lookup
+test('self bracket lookup resolves variable by name', function () {
+    assertTemplateResult('bar', '{{ self[key] }}', staticData: ['key' => 'foo', 'foo' => 'bar']);
+});
+
+// US 2: dot lookup
+test('self dot lookup accesses variable by property name', function () {
+    assertTemplateResult('bar', '{{ self.foo }}', staticData: ['foo' => 'bar']);
+});
+
+// US 3: scope chain — local variable shadows broader
+test('self lookup uses normal scope hierarchy', function () {
+    assertTemplateResult('local', '{% assign foo = "local" %}{{ self.foo }}');
+});
+
+// US 4: explicit self assignment shadows implicit self drop
+test('explicit self variable shadows fallback self drop', function () {
+    assertTemplateResult('override', '{% assign self = "override" %}{{ self }}');
+    assertTemplateResult('', '{% assign self = "override" %}{{ self.foo }}');
+});
+
+// US 5: dynamic key that is itself a variable
+test('self bracket lookup with variable key', function () {
+    assertTemplateResult('Alice', '{{ self[key] }}', staticData: ['key' => 'name', 'name' => 'Alice']);
+});
+
+// US 6: nested expression
+test('self bracket lookup can be composed in nested expression', function () {
+    assertTemplateResult('found', '{{ a[self["b"]] }}', staticData: ['b' => 'x', 'x' => 'found', 'a' => ['found' => 'found', 'x' => 'found']]);
+});
+
+// US 7 & 11: assigned self reflects later changes (no snapshot)
+test('self assigned to variable reflects later assignments', function () {
+    assertTemplateResult('late', '{% assign s = self %}{% assign foo = "late" %}{{ s.foo }}');
+});
+
+// US 8: self passed to partial keeps caller context
+// data (not staticData) is local to the root context and not accessible in partials normally.
+// A passed self retains the root context, so {{ self.outer }} resolves through root's data.
+test('self passed to partial keeps caller context', function () {
+    assertTemplateResult('caller_value', '{% render "partial", self: self %}', data: ['outer' => 'caller_value'], partials: [
+        'partial' => '{{ self.outer }}',
+    ]);
+});
+
+// US 9: implicit self in partial is isolated to its own scope
+// The partial's own implicit self cannot see root's local data.
+test('implicit self in partial is isolated to partial scope', function () {
+    assertTemplateResult('', '{% render "partial" %}', data: ['outer' => 'caller_value'], partials: [
+        'partial' => '{{ self.outer }}',
+    ]);
+});
+
+// US 10: nested partials preserve each self context independently.
+// Middle's implicit self sees middle's own assigns.
+// Inner receives middle's implicit self, so it also sees middle's assigns.
+// Neither sees root's local data (which is not accessible via implicit self in a partial).
+test('nested partials preserve each self context independently', function () {
+    // Middle's implicit self sees its own assign; inner gets middle's self and sees middle_var.
+    assertTemplateResult('middle_value', '{% render "middle" %}', partials: [
+        'middle' => '{% assign middle_var = "middle_value" %}{% render "inner", self: self %}',
+        'inner' => '{{ self.middle_var }}',
+    ]);
+
+    // Root passes its own self to middle; middle's explicit self can see root's local data.
+    assertTemplateResult('root_value', '{% render "middle", self: self %}', data: ['root_var' => 'root_value'], partials: [
+        'middle' => '{{ self.root_var }}',
+    ]);
+});
+
+// US 12: repeated self lookups compare equal
+test('repeated self lookups compare equal', function () {
+    assertTemplateResult('yes', '{% if self == self %}yes{% endif %}');
+});
+
+// US 13: two variables assigned from same self context compare equal
+test('two variables from same self context compare equal', function () {
+    assertTemplateResult('yes', '{% assign a = self %}{% assign b = self %}{% if a == b %}yes{% endif %}');
+});
+
+// US 14: missing property renders blank under strict variables
+test('self missing property renders blank under strict variables', function () {
+    $factory = new EnvironmentFactory;
+    $factory->setStrictVariables(true);
+    assertTemplateResult('', '{{ self.missing_key }}', factory: $factory);
+});
+
+// US 15: explicit null self is not confused with missing self
+test('explicit null self does not trigger self drop fallback', function () {
+    assertTemplateResult('', '{% assign self = nil %}{{ self }}');
+    // The assigned nil should be returned, not the SelfDrop
+    assertTemplateResult('yes', '{% assign self = nil %}{% if self == nil %}yes{% endif %}');
+});
+
+// Regression: self.self does not infinitely recurse and renders blank
+test('self dot self renders blank without infinite recursion', function () {
+    assertTemplateResult('', '{{ self.self }}');
+});

--- a/tests/Integration/SelfDropTest.php
+++ b/tests/Integration/SelfDropTest.php
@@ -2,63 +2,47 @@
 
 use Keepsuit\Liquid\EnvironmentFactory;
 
-// US 1: dynamic bracket lookup
 test('self bracket lookup resolves variable by name', function () {
     assertTemplateResult('bar', '{{ self[key] }}', staticData: ['key' => 'foo', 'foo' => 'bar']);
 });
 
-// US 2: dot lookup
 test('self dot lookup accesses variable by property name', function () {
     assertTemplateResult('bar', '{{ self.foo }}', staticData: ['foo' => 'bar']);
 });
 
-// US 3: scope chain — local variable shadows broader
 test('self lookup uses normal scope hierarchy', function () {
     assertTemplateResult('local', '{% assign foo = "local" %}{{ self.foo }}');
 });
 
-// US 4: explicit self assignment shadows implicit self drop
 test('explicit self variable shadows fallback self drop', function () {
     assertTemplateResult('override', '{% assign self = "override" %}{{ self }}');
     assertTemplateResult('', '{% assign self = "override" %}{{ self.foo }}');
 });
 
-// US 5: dynamic key that is itself a variable
 test('self bracket lookup with variable key', function () {
     assertTemplateResult('Alice', '{{ self[key] }}', staticData: ['key' => 'name', 'name' => 'Alice']);
 });
 
-// US 6: nested expression
 test('self bracket lookup can be composed in nested expression', function () {
     assertTemplateResult('found', '{{ a[self["b"]] }}', staticData: ['b' => 'x', 'x' => 'found', 'a' => ['found' => 'found', 'x' => 'found']]);
 });
 
-// US 7 & 11: assigned self reflects later changes (no snapshot)
 test('self assigned to variable reflects later assignments', function () {
     assertTemplateResult('late', '{% assign s = self %}{% assign foo = "late" %}{{ s.foo }}');
 });
 
-// US 8: self passed to partial keeps caller context
-// data (not staticData) is local to the root context and not accessible in partials normally.
-// A passed self retains the root context, so {{ self.outer }} resolves through root's data.
 test('self passed to partial keeps caller context', function () {
     assertTemplateResult('caller_value', '{% render "partial", self: self %}', data: ['outer' => 'caller_value'], partials: [
         'partial' => '{{ self.outer }}',
     ]);
 });
 
-// US 9: implicit self in partial is isolated to its own scope
-// The partial's own implicit self cannot see root's local data.
 test('implicit self in partial is isolated to partial scope', function () {
     assertTemplateResult('', '{% render "partial" %}', data: ['outer' => 'caller_value'], partials: [
         'partial' => '{{ self.outer }}',
     ]);
 });
 
-// US 10: nested partials preserve each self context independently.
-// Middle's implicit self sees middle's own assigns.
-// Inner receives middle's implicit self, so it also sees middle's assigns.
-// Neither sees root's local data (which is not accessible via implicit self in a partial).
 test('nested partials preserve each self context independently', function () {
     // Middle's implicit self sees its own assign; inner gets middle's self and sees middle_var.
     assertTemplateResult('middle_value', '{% render "middle" %}', partials: [
@@ -72,38 +56,30 @@ test('nested partials preserve each self context independently', function () {
     ]);
 });
 
-// US 12: repeated self lookups compare equal
 test('repeated self lookups compare equal', function () {
     assertTemplateResult('yes', '{% if self == self %}yes{% endif %}');
 });
 
-// Upstream: test_assigned_self_drop_compares_equal_to_itself
 test('assigned self drop compares equal to itself', function () {
     assertTemplateResult('T', '{% assign s = self %}{% if s == s %}T{% else %}F{% endif %}');
 });
 
-// US 13: two variables assigned from same self context compare equal
 test('two variables from same self context compare equal', function () {
     assertTemplateResult('yes', '{% assign a = self %}{% assign b = self %}{% if a == b %}yes{% endif %}');
 });
 
-// US 14: missing property renders blank under strict variables
 test('self missing property renders blank under strict variables', function () {
     $factory = new EnvironmentFactory;
     $factory->setStrictVariables(true);
     assertTemplateResult('', '{{ self.missing_key }}', factory: $factory);
 });
 
-// Upstream: test_self_drop_with_strict_variables_does_not_raise_for_defined_var
 test('self defined property resolves correctly under strict variables', function () {
     $factory = new EnvironmentFactory;
     $factory->setStrictVariables(true);
     assertTemplateResult('42', '{{ self.x }}', staticData: ['x' => 42], factory: $factory);
 });
 
-// Upstream: test_self_drop_passed_as_render_param_preserves_original_scope
-// Both the caller and partial use the same variable name; the passed self must hold
-// the caller's value while the partial's implicit self holds the partial's own.
 test('self passed as render param preserves original scope when variable name collides', function () {
     assertTemplateResult('42|43',
         '{%- assign var = 42 -%}{%- assign s = self -%}{%- render "snippet", other_self: s -%}',
@@ -113,9 +89,6 @@ test('self passed as render param preserves original scope when variable name co
     );
 });
 
-// Upstream: test_self_drop_passed_to_nested_renders_preserves_each_level
-// Three levels all shadow the same variable `a`; each passed self must resolve
-// to its own level's value independently.
 test('self passed to nested renders preserves each level independently', function () {
     assertTemplateResult('1|2|3',
         '{%- assign a = 1 -%}{%- assign s1 = self -%}{%- render "snippet1", outer: s1 -%}',
@@ -126,14 +99,12 @@ test('self passed to nested renders preserves each level independently', functio
     );
 });
 
-// US 15: explicit null self is not confused with missing self
 test('explicit null self does not trigger self drop fallback', function () {
     assertTemplateResult('', '{% assign self = nil %}{{ self }}');
     // The assigned nil should be returned, not the SelfDrop
     assertTemplateResult('yes', '{% assign self = nil %}{% if self == nil %}yes{% endif %}');
 });
 
-// Regression: self.self does not infinitely recurse and renders blank
 test('self dot self renders blank without infinite recursion', function () {
     assertTemplateResult('', '{{ self.self }}');
 });

--- a/tests/Integration/SelfDropTest.php
+++ b/tests/Integration/SelfDropTest.php
@@ -77,6 +77,11 @@ test('repeated self lookups compare equal', function () {
     assertTemplateResult('yes', '{% if self == self %}yes{% endif %}');
 });
 
+// Upstream: test_assigned_self_drop_compares_equal_to_itself
+test('assigned self drop compares equal to itself', function () {
+    assertTemplateResult('T', '{% assign s = self %}{% if s == s %}T{% else %}F{% endif %}');
+});
+
 // US 13: two variables assigned from same self context compare equal
 test('two variables from same self context compare equal', function () {
     assertTemplateResult('yes', '{% assign a = self %}{% assign b = self %}{% if a == b %}yes{% endif %}');
@@ -87,6 +92,38 @@ test('self missing property renders blank under strict variables', function () {
     $factory = new EnvironmentFactory;
     $factory->setStrictVariables(true);
     assertTemplateResult('', '{{ self.missing_key }}', factory: $factory);
+});
+
+// Upstream: test_self_drop_with_strict_variables_does_not_raise_for_defined_var
+test('self defined property resolves correctly under strict variables', function () {
+    $factory = new EnvironmentFactory;
+    $factory->setStrictVariables(true);
+    assertTemplateResult('42', '{{ self.x }}', staticData: ['x' => 42], factory: $factory);
+});
+
+// Upstream: test_self_drop_passed_as_render_param_preserves_original_scope
+// Both the caller and partial use the same variable name; the passed self must hold
+// the caller's value while the partial's implicit self holds the partial's own.
+test('self passed as render param preserves original scope when variable name collides', function () {
+    assertTemplateResult('42|43',
+        '{%- assign var = 42 -%}{%- assign s = self -%}{%- render "snippet", other_self: s -%}',
+        partials: [
+            'snippet' => '{%- assign var = 43 -%}{{- other_self.var }}|{{ self.var -}}',
+        ]
+    );
+});
+
+// Upstream: test_self_drop_passed_to_nested_renders_preserves_each_level
+// Three levels all shadow the same variable `a`; each passed self must resolve
+// to its own level's value independently.
+test('self passed to nested renders preserves each level independently', function () {
+    assertTemplateResult('1|2|3',
+        '{%- assign a = 1 -%}{%- assign s1 = self -%}{%- render "snippet1", outer: s1 -%}',
+        partials: [
+            'snippet1' => '{%- assign a = 2 -%}{%- assign s2 = self -%}{%- render "snippet2", outer: outer, middle: s2 -%}',
+            'snippet2' => '{%- assign a = 3 -%}{{- outer.a }}|{{ middle.a }}|{{ self.a -}}',
+        ]
+    );
 });
 
 // US 15: explicit null self is not confused with missing self

--- a/tests/Integration/Tags/AssignTagTest.php
+++ b/tests/Integration/Tags/AssignTagTest.php
@@ -86,14 +86,14 @@ test('assign score exceeding resource limit from composite object', function () 
 
 test('assign strict parsing rejects dotted target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Expected ==, got . - Valid syntax: assign [var] = [source]',
+        'Liquid syntax error (line 1): Expected ==, got . - Valid syntax: assign <var> = <source>',
         '{% assign foo.bar = "x" %}',
     );
 });
 
 test('assign strict parsing rejects bracketed target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Expected ==, got [ - Valid syntax: assign [var] = [source]',
+        'Liquid syntax error (line 1): Expected ==, got [ - Valid syntax: assign <var> = <source>',
         '{% assign foo[bar] = "x" %}',
     );
 });

--- a/tests/Integration/Tags/AssignTagTest.php
+++ b/tests/Integration/Tags/AssignTagTest.php
@@ -86,14 +86,14 @@ test('assign score exceeding resource limit from composite object', function () 
 
 test('assign strict parsing rejects dotted target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: assign [var] = [source]',
+        'Liquid syntax error (line 1): Expected ==, got . - Valid syntax: assign [var] = [source]',
         '{% assign foo.bar = "x" %}',
     );
 });
 
 test('assign strict parsing rejects bracketed target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: assign [var] = [source]',
+        'Liquid syntax error (line 1): Expected ==, got [ - Valid syntax: assign [var] = [source]',
         '{% assign foo[bar] = "x" %}',
     );
 });

--- a/tests/Integration/Tags/AssignTagTest.php
+++ b/tests/Integration/Tags/AssignTagTest.php
@@ -84,6 +84,20 @@ test('assign score exceeding resource limit from composite object', function () 
     expect($context->resourceLimits->getAssignScore())->toBe(5);
 });
 
+test('assign strict parsing rejects dotted target', function () {
+    assertMatchSyntaxError(
+        "Liquid syntax error (line 1): Syntax Error in 'assign' - Valid syntax: assign [var] = [source]",
+        '{% assign foo.bar = "x" %}',
+    );
+});
+
+test('assign strict parsing rejects bracketed target', function () {
+    assertMatchSyntaxError(
+        "Liquid syntax error (line 1): Syntax Error in 'assign' - Valid syntax: assign [var] = [source]",
+        '{% assign foo[bar] = "x" %}',
+    );
+});
+
 test('assign score of int', function () {
     expect(assignScoreOf(123))->toBe(1);
 });

--- a/tests/Integration/Tags/AssignTagTest.php
+++ b/tests/Integration/Tags/AssignTagTest.php
@@ -40,10 +40,10 @@ test('assigned with filter', function () {
 
 test('assign syntax error', function () {
     expect(fn () => renderTemplate('{% assign foo not values %}.'))
-        ->toThrow(SyntaxException::class, 'assign');
+        ->toThrow(SyntaxException::class);
 
     expect(fn () => renderTemplate("{% assign foo = ('X' | downcase) %}"))
-        ->toThrow(SyntaxException::class, 'assign');
+        ->toThrow(SyntaxException::class);
 });
 
 test('expression with whitespace in square brackets', function () {
@@ -86,14 +86,14 @@ test('assign score exceeding resource limit from composite object', function () 
 
 test('assign strict parsing rejects dotted target', function () {
     assertMatchSyntaxError(
-        "Liquid syntax error (line 1): Syntax Error in 'assign' - Valid syntax: assign [var] = [source]",
+        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: assign [var] = [source]',
         '{% assign foo.bar = "x" %}',
     );
 });
 
 test('assign strict parsing rejects bracketed target', function () {
     assertMatchSyntaxError(
-        "Liquid syntax error (line 1): Syntax Error in 'assign' - Valid syntax: assign [var] = [source]",
+        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: assign [var] = [source]',
         '{% assign foo[bar] = "x" %}',
     );
 });

--- a/tests/Integration/Tags/CaptureTagTest.php
+++ b/tests/Integration/Tags/CaptureTagTest.php
@@ -46,21 +46,21 @@ test('assigning from capture', function () {
 
 test('capture strict parsing rejects dotted target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Unexpected token .: "." - Valid syntax: capture [var]',
+        'Liquid syntax error (line 1): Unexpected token .: "." - Valid syntax: capture <var>',
         '{% capture foo.bar %}x{% endcapture %}',
     );
 });
 
 test('capture strict parsing rejects bracketed target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Unexpected token [: "[" - Valid syntax: capture [var]',
+        'Liquid syntax error (line 1): Unexpected token [: "[" - Valid syntax: capture <var>',
         '{% capture foo[bar] %}x{% endcapture %}',
     );
 });
 
 test('capture strict parsing rejects quoted string target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Expected Identifier, got String - Valid syntax: capture [var]',
+        'Liquid syntax error (line 1): Expected Identifier, got String - Valid syntax: capture <var>',
         "{% capture 'foo' %}x{% endcapture %}",
     );
 });

--- a/tests/Integration/Tags/CaptureTagTest.php
+++ b/tests/Integration/Tags/CaptureTagTest.php
@@ -46,21 +46,21 @@ test('assigning from capture', function () {
 
 test('capture strict parsing rejects dotted target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: capture [var]',
+        'Liquid syntax error (line 1): Unexpected token .: "." - Valid syntax: capture [var]',
         '{% capture foo.bar %}x{% endcapture %}',
     );
 });
 
 test('capture strict parsing rejects bracketed target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: capture [var]',
+        'Liquid syntax error (line 1): Unexpected token [: "[" - Valid syntax: capture [var]',
         '{% capture foo[bar] %}x{% endcapture %}',
     );
 });
 
 test('capture strict parsing rejects quoted string target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: capture [var]',
+        'Liquid syntax error (line 1): Expected Identifier, got String - Valid syntax: capture [var]',
         "{% capture 'foo' %}x{% endcapture %}",
     );
 });

--- a/tests/Integration/Tags/CaptureTagTest.php
+++ b/tests/Integration/Tags/CaptureTagTest.php
@@ -44,6 +44,20 @@ test('assigning from capture', function () {
     assertTemplateResult('3-3', $source);
 });
 
+test('capture strict parsing rejects dotted target', function () {
+    assertMatchSyntaxError(
+        "Liquid syntax error (line 1): Syntax Error in 'capture' - Valid syntax: capture [var]",
+        '{% capture foo.bar %}x{% endcapture %}',
+    );
+});
+
+test('capture strict parsing rejects bracketed target', function () {
+    assertMatchSyntaxError(
+        "Liquid syntax error (line 1): Syntax Error in 'capture' - Valid syntax: capture [var]",
+        '{% capture foo[bar] %}x{% endcapture %}',
+    );
+});
+
 test('increment assign score by bytes', function () {
     $context = new RenderContext;
     parseTemplate('{% capture foo %}すごい{% endcapture %}')->render($context);

--- a/tests/Integration/Tags/CaptureTagTest.php
+++ b/tests/Integration/Tags/CaptureTagTest.php
@@ -46,21 +46,21 @@ test('assigning from capture', function () {
 
 test('capture strict parsing rejects dotted target', function () {
     assertMatchSyntaxError(
-        "Liquid syntax error (line 1): Syntax Error in 'capture' - Valid syntax: capture [var]",
+        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: capture [var]',
         '{% capture foo.bar %}x{% endcapture %}',
     );
 });
 
 test('capture strict parsing rejects bracketed target', function () {
     assertMatchSyntaxError(
-        "Liquid syntax error (line 1): Syntax Error in 'capture' - Valid syntax: capture [var]",
+        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: capture [var]',
         '{% capture foo[bar] %}x{% endcapture %}',
     );
 });
 
 test('capture strict parsing rejects quoted string target', function () {
     assertMatchSyntaxError(
-        "Liquid syntax error (line 1): Syntax Error in 'capture' - Valid syntax: capture [var]",
+        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: capture [var]',
         "{% capture 'foo' %}x{% endcapture %}",
     );
 });

--- a/tests/Integration/Tags/CaptureTagTest.php
+++ b/tests/Integration/Tags/CaptureTagTest.php
@@ -3,7 +3,7 @@
 use Keepsuit\Liquid\Render\RenderContext;
 
 test('capture block content in variable', function () {
-    assertTemplateResult('test string', "{% capture 'var' %}test string{% endcapture %}{{var}}");
+    assertTemplateResult('test string', '{% capture var %}test string{% endcapture %}{{var}}');
 });
 
 test('capture with hyphen in variable name', function () {
@@ -55,6 +55,13 @@ test('capture strict parsing rejects bracketed target', function () {
     assertMatchSyntaxError(
         "Liquid syntax error (line 1): Syntax Error in 'capture' - Valid syntax: capture [var]",
         '{% capture foo[bar] %}x{% endcapture %}',
+    );
+});
+
+test('capture strict parsing rejects quoted string target', function () {
+    assertMatchSyntaxError(
+        "Liquid syntax error (line 1): Syntax Error in 'capture' - Valid syntax: capture [var]",
+        "{% capture 'foo' %}x{% endcapture %}",
     );
 });
 

--- a/tests/Integration/Tags/DocTagTest.php
+++ b/tests/Integration/Tags/DocTagTest.php
@@ -21,7 +21,7 @@ test('doc tag does not support extra arguments', function () {
     {% enddoc %}
     LIQUID;
 
-    assertMatchSyntaxError('Liquid syntax error (line 2): Unexpected token Identifier: "extra"', $template);
+    assertMatchSyntaxError('Liquid syntax error (line 2): Unexpected token Identifier: "extra" - Valid syntax: doc', $template);
 });
 
 test('doc tag must support valid tags', function () {
@@ -65,7 +65,7 @@ test('doc tag does not allow nested docs', function () {
     {% enddoc %}
     LIQUID;
 
-    assertMatchSyntaxError('Liquid syntax error (line 4): Nested doc tags are not allowed', $template);
+    assertMatchSyntaxError('Liquid syntax error (line 4): Nested doc tags are not allowed - Valid syntax: doc', $template);
 });
 
 test('doc tag ignores nested raw tags', function () {

--- a/tests/Integration/Tags/IncrementTagTest.php
+++ b/tests/Integration/Tags/IncrementTagTest.php
@@ -35,28 +35,28 @@ test('decrement', function () {
 
 test('increment strict parsing rejects dotted target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: increment [var]',
+        'Liquid syntax error (line 1): Unexpected token .: "." - Valid syntax: increment [var]',
         '{% increment foo.bar %}',
     );
 });
 
 test('increment strict parsing rejects bracketed target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: increment [var]',
+        'Liquid syntax error (line 1): Unexpected token [: "[" - Valid syntax: increment [var]',
         '{% increment foo[bar] %}',
     );
 });
 
 test('decrement strict parsing rejects dotted target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: decrement [var]',
+        'Liquid syntax error (line 1): Unexpected token .: "." - Valid syntax: decrement [var]',
         '{% decrement foo.bar %}',
     );
 });
 
 test('decrement strict parsing rejects bracketed target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: decrement [var]',
+        'Liquid syntax error (line 1): Unexpected token [: "[" - Valid syntax: decrement [var]',
         '{% decrement foo[bar] %}',
     );
 });

--- a/tests/Integration/Tags/IncrementTagTest.php
+++ b/tests/Integration/Tags/IncrementTagTest.php
@@ -32,3 +32,31 @@ test('decrement', function () {
         LIQUID
     );
 });
+
+test('increment strict parsing rejects dotted target', function () {
+    assertMatchSyntaxError(
+        'Liquid syntax error (line 1): Invalid variable name',
+        '{% increment foo.bar %}',
+    );
+});
+
+test('increment strict parsing rejects bracketed target', function () {
+    assertMatchSyntaxError(
+        'Liquid syntax error (line 1): Invalid variable name',
+        '{% increment foo[bar] %}',
+    );
+});
+
+test('decrement strict parsing rejects dotted target', function () {
+    assertMatchSyntaxError(
+        'Liquid syntax error (line 1): Invalid variable name',
+        '{% decrement foo.bar %}',
+    );
+});
+
+test('decrement strict parsing rejects bracketed target', function () {
+    assertMatchSyntaxError(
+        'Liquid syntax error (line 1): Invalid variable name',
+        '{% decrement foo[bar] %}',
+    );
+});

--- a/tests/Integration/Tags/IncrementTagTest.php
+++ b/tests/Integration/Tags/IncrementTagTest.php
@@ -35,28 +35,28 @@ test('decrement', function () {
 
 test('increment strict parsing rejects dotted target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Unexpected token .: "." - Valid syntax: increment [var]',
+        'Liquid syntax error (line 1): Unexpected token .: "." - Valid syntax: increment <var>',
         '{% increment foo.bar %}',
     );
 });
 
 test('increment strict parsing rejects bracketed target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Unexpected token [: "[" - Valid syntax: increment [var]',
+        'Liquid syntax error (line 1): Unexpected token [: "[" - Valid syntax: increment <var>',
         '{% increment foo[bar] %}',
     );
 });
 
 test('decrement strict parsing rejects dotted target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Unexpected token .: "." - Valid syntax: decrement [var]',
+        'Liquid syntax error (line 1): Unexpected token .: "." - Valid syntax: decrement <var>',
         '{% decrement foo.bar %}',
     );
 });
 
 test('decrement strict parsing rejects bracketed target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Unexpected token [: "[" - Valid syntax: decrement [var]',
+        'Liquid syntax error (line 1): Unexpected token [: "[" - Valid syntax: decrement <var>',
         '{% decrement foo[bar] %}',
     );
 });

--- a/tests/Integration/Tags/IncrementTagTest.php
+++ b/tests/Integration/Tags/IncrementTagTest.php
@@ -35,28 +35,28 @@ test('decrement', function () {
 
 test('increment strict parsing rejects dotted target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Invalid variable name',
+        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: increment [var]',
         '{% increment foo.bar %}',
     );
 });
 
 test('increment strict parsing rejects bracketed target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Invalid variable name',
+        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: increment [var]',
         '{% increment foo[bar] %}',
     );
 });
 
 test('decrement strict parsing rejects dotted target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Invalid variable name',
+        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: decrement [var]',
         '{% decrement foo.bar %}',
     );
 });
 
 test('decrement strict parsing rejects bracketed target', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Invalid variable name',
+        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: decrement [var]',
         '{% decrement foo[bar] %}',
     );
 });

--- a/tests/Integration/Tags/StandardTagTest.php
+++ b/tests/Integration/Tags/StandardTagTest.php
@@ -75,7 +75,7 @@ test('capture', function () {
 
 test('capture detects bad syntax', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: capture [var]',
+        'Liquid syntax error (line 1): Unexpected end of template - Valid syntax: capture [var]',
         '{{ var2 }}{% capture %}{{ var }} foo {% endcapture %}{{ var2 }}{{ var2 }}',
         staticData: ['var' => 'content']
     );

--- a/tests/Integration/Tags/StandardTagTest.php
+++ b/tests/Integration/Tags/StandardTagTest.php
@@ -75,7 +75,7 @@ test('capture', function () {
 
 test('capture detects bad syntax', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Syntax Error in \'capture\' - Valid syntax: capture [var]',
+        'Liquid syntax error (line 1): Expected a simple variable name - Valid syntax: capture [var]',
         '{{ var2 }}{% capture %}{{ var }} foo {% endcapture %}{{ var2 }}{{ var2 }}',
         staticData: ['var' => 'content']
     );

--- a/tests/Integration/Tags/StandardTagTest.php
+++ b/tests/Integration/Tags/StandardTagTest.php
@@ -75,7 +75,7 @@ test('capture', function () {
 
 test('capture detects bad syntax', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Unexpected end of template - Valid syntax: capture [var]',
+        'Liquid syntax error (line 1): Unexpected end of template - Valid syntax: capture <var>',
         '{{ var2 }}{% capture %}{{ var }} foo {% endcapture %}{{ var2 }}{{ var2 }}',
         staticData: ['var' => 'content']
     );
@@ -249,17 +249,17 @@ test('case when comma and blank body', function () {
 
 test('case strict parsing rejects trailing tokens', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Unexpected token Identifier: "extra"',
+        'Liquid syntax error (line 1): Unexpected token Identifier: "extra" - Valid syntax: case <expression>',
         '{% case condition extra %}{% when 1 %} hit {% endcase %}',
         staticData: ['condition' => 1],
     );
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Unexpected token Identifier: "extra"',
+        'Liquid syntax error (line 1): Unexpected token Identifier: "extra" - Valid syntax: when <expression> [, <expression>...]',
         '{% case condition %}{% when 1 extra %} hit {% endcase %}',
         staticData: ['condition' => 1],
     );
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Unexpected end of template',
+        'Liquid syntax error (line 1): Unexpected end of template - Valid syntax: when <expression> [, <expression>...]',
         '{% case condition %}{% when 1, %} hit {% endcase %}',
         staticData: ['condition' => 1],
     );
@@ -322,7 +322,7 @@ test('multiple named cycle with name from context', function () {
 
 test('cycle strict parsing rejects trailing tokens', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Unexpected token Identifier: "extra"',
+        'Liquid syntax error (line 1): Unexpected token Identifier: "extra" - Valid syntax: cycle [<name>:] <value>[, <value>...]',
         '{% cycle "one", "two" extra %}',
     );
 });

--- a/tests/Integration/Tags/TableRowTest.php
+++ b/tests/Integration/Tags/TableRowTest.php
@@ -289,12 +289,12 @@ test('tablerow renders correct error message for invalid parameters', function (
 
 test('tablerow strict parsing rejects malformed params', function () {
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Expected :, got Number',
+        'Liquid syntax error (line 1): Expected :, got Number - Valid syntax: tablerow <var> in <collection> [attributes...]',
         '{% tablerow n in numbers cols 3 %}{% endtablerow %}',
         ['numbers' => [1, 2, 3]],
     );
     assertMatchSyntaxError(
-        'Liquid syntax error (line 1): Unexpected end of template',
+        'Liquid syntax error (line 1): Unexpected end of template - Valid syntax: tablerow <var> in <collection> [attributes...]',
         '{% tablerow n in numbers cols: 3, limit %}{% endtablerow %}',
         ['numbers' => [1, 2, 3]],
     );


### PR DESCRIPTION
## Summary
- Add `self` drop support so templates can read `self.foo`, `self[key]`, and pass `self` across render boundaries with correct scope behavior.
- Harden tag parsing for `assign`, `capture`, `increment`, and `decrement` so dotted and bracketed targets now fail at parse time.
- Update README and changelog for the v0.11.0 / Shopify Liquid v5.13 compatibility release.
- Add integration coverage for `self` lookup behavior, nested partials, null handling, and parser rejection cases.

## Testing
- Added integration tests in `tests/Integration/SelfDropTest.php` covering property lookup, bracket lookup, partial scope isolation, and regression cases.
- Added parser rejection tests in `tests/Integration/Tags/AssignTagTest.php`, `tests/Integration/Tags/CaptureTagTest.php`, and `tests/Integration/Tags/IncrementTagTest.php`.
- Not run