### PR TITLE
Run all PHPBench subjects on every PHP version

### DIFF
--- a/.github/workflows/phpbench.yml
+++ b/.github/workflows/phpbench.yml
@@ -73,7 +73,6 @@ jobs:
           set -euo pipefail
 
           vendor/bin/phpbench run \
-            --progress=none \
             --warmup=1 \
             --report=aggregate \
             --output=json > "$WORKSPACE/pr.json"
@@ -84,7 +83,6 @@ jobs:
           set -euo pipefail
 
           vendor/bin/phpbench run \
-            --progress=none \
             --warmup=1 \
             --report=aggregate \
             --output=json > "$WORKSPACE/base.json"

--- a/.github/workflows/phpbench.yml
+++ b/.github/workflows/phpbench.yml
@@ -72,13 +72,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          PHPBENCH_FILTER=()
-          if [[ "${{ matrix.php }}" == "8.4" || "${{ matrix.php }}" == "8.5" ]]; then
-            PHPBENCH_FILTER+=(--filter='^(?!.*TemplateCacheBench::benchVarExporter$).*')
-          fi
-
           vendor/bin/phpbench run \
-            "${PHPBENCH_FILTER[@]}" \
             --progress=none \
             --warmup=1 \
             --report=aggregate \
@@ -89,13 +83,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          PHPBENCH_FILTER=()
-          if [[ "${{ matrix.php }}" == "8.4" || "${{ matrix.php }}" == "8.5" ]]; then
-            PHPBENCH_FILTER+=(--filter='^(?!.*TemplateCacheBench::benchVarExporter$).*')
-          fi
-
           vendor/bin/phpbench run \
-            "${PHPBENCH_FILTER[@]}" \
             --progress=none \
             --warmup=1 \
             --report=aggregate \


### PR DESCRIPTION
Removes the PHP 8.4/8.5 filter so `TemplateCacheBench::benchVarExporter` runs in every PR benchmark comparison.