### PR TITLE
Experiment: store tokens as raw arrays instead of Token objects

### DIFF
--- a/src/Parse/ArgumentParser.php
+++ b/src/Parse/ArgumentParser.php
@@ -30,10 +30,10 @@ class ArgumentParser
             $this->tokenStream->look(TokenType::Identifier)
             && $this->tokenStream->look(TokenType::Colon, 1)
         ) {
-            $identifier = $this->tokenStream->consume(TokenType::Identifier);
+            $identifier = $this->tokenStream->consumeData(TokenType::Identifier);
             $this->tokenStream->consume(TokenType::Colon);
 
-            return [$identifier->data => $this->tokenStream->expression()];
+            return [$identifier => $this->tokenStream->expression()];
         }
 
         return $this->tokenStream->expression();

--- a/src/Parse/ExpressionParser.php
+++ b/src/Parse/ExpressionParser.php
@@ -33,25 +33,25 @@ class ExpressionParser
      */
     public function parseExpression(): mixed
     {
-        $token = $this->tokenStream->current();
+        $token = $this->tokenStream->currentRaw();
 
         if ($token === null) {
             return null;
         }
 
-        return match ($token->type) {
+        return match ($token[0]) {
             TokenType::OpenRound => $this->parseRange(),
             TokenType::String => $this->parseString(),
             TokenType::Number => $this->parseNumber(),
-            TokenType::Identifier => array_key_exists($token->data, self::LITERALS) ? $this->parseLiteral() : $this->parseVariable(),
+            TokenType::Identifier => array_key_exists($token[1], self::LITERALS) ? $this->parseLiteral() : $this->parseVariable(),
             TokenType::VariableEnd => null,
-            default => throw SyntaxException::invalidExpression($token->data),
+            default => throw SyntaxException::invalidExpression($token[1]),
         };
     }
 
     protected function parseVariable(): VariableLookup
     {
-        $name = $this->tokenStream->consume(TokenType::Identifier)->data;
+        $name = $this->tokenStream->consumeData(TokenType::Identifier);
         $lookups = $this->parseVariableLookups();
 
         return new VariableLookup(
@@ -68,12 +68,12 @@ class ExpressionParser
         $lookups = [];
 
         while (true) {
-            if ($this->tokenStream->consumeOrFalse(TokenType::Dot)) {
-                $lookups[] = $this->tokenStream->consume(TokenType::Identifier)->data;
+            if ($this->tokenStream->consumeIf(TokenType::Dot)) {
+                $lookups[] = $this->tokenStream->consumeData(TokenType::Identifier);
 
                 continue;
             }
-            if ($this->tokenStream->consumeOrFalse(TokenType::OpenSquare)) {
+            if ($this->tokenStream->consumeIf(TokenType::OpenSquare)) {
                 $lookups[] = $this->tokenStream->expression();
                 $this->tokenStream->consume(TokenType::CloseSquare);
 
@@ -105,29 +105,27 @@ class ExpressionParser
 
     protected function parseString(): string
     {
-        $token = $this->tokenStream->consume(TokenType::String);
+        $data = $this->tokenStream->consumeData(TokenType::String);
 
         if (
-            (str_starts_with($token->data, '"') && str_ends_with($token->data, '"')) ||
-            (str_starts_with($token->data, "'") && str_ends_with($token->data, "'"))
+            (str_starts_with($data, '"') && str_ends_with($data, '"')) ||
+            (str_starts_with($data, "'") && str_ends_with($data, "'"))
         ) {
-            return substr($token->data, 1, -1);
+            return substr($data, 1, -1);
         }
 
-        return $token->data;
+        return $data;
     }
 
     protected function parseNumber(): int|float
     {
-        $token = $this->tokenStream->consume(TokenType::Number);
+        $data = $this->tokenStream->consumeData(TokenType::Number);
 
-        return str_contains($token->data, '.') ? (float) $token->data : (int) $token->data;
+        return str_contains($data, '.') ? (float) $data : (int) $data;
     }
 
     protected function parseLiteral(): mixed
     {
-        $token = $this->tokenStream->consume(TokenType::Identifier);
-
-        return self::LITERALS[$token->data];
+        return self::LITERALS[$this->tokenStream->consumeData(TokenType::Identifier)];
     }
 }

--- a/src/Parse/Lexer.php
+++ b/src/Parse/Lexer.php
@@ -31,7 +31,10 @@ class Lexer
     protected LexerState $state;
 
     /**
-     * @var Token[]
+     * Raw token triples: [TokenType, data, lineNumber]. Kept as arrays rather
+     * than Token objects because object allocation dominated tokenize time.
+     *
+     * @var list<array{0: TokenType, 1: string, 2: int}>
      */
     protected array $tokens;
 
@@ -148,7 +151,7 @@ class Lexer
 
         $terminator = $this->terminatorLength(LexerOptions::TagVariableEnd->value);
         if ($terminator !== null) {
-            $this->tokens[] = new Token(TokenType::VariableEnd, '', $lineNumber);
+            $this->tokens[] = [TokenType::VariableEnd, '', $lineNumber];
             $this->skip($terminator);
             $this->popState();
 
@@ -180,7 +183,7 @@ class Lexer
                 throw SyntaxException::unexpectedEndOfTemplate();
             }
 
-            if ($tag === null && $lastToken->type === TokenType::Identifier) {
+            if ($tag === null && $lastToken[0] === TokenType::Identifier) {
                 $tag = $lastToken;
             }
         }
@@ -196,7 +199,7 @@ class Lexer
             throw SyntaxException::unexpectedEndOfTemplate();
         }
 
-        if ($lastToken->type === TokenType::BlockStart) {
+        if ($lastToken[0] === TokenType::BlockStart) {
             array_pop($this->tokens);
         } else {
             $this->pushToken(TokenType::BlockEnd);
@@ -204,8 +207,8 @@ class Lexer
 
         $this->popState();
 
-        if ($tag !== null && isset($this->rawBodyTags[$tag->data])) {
-            $this->lexRawBodyTag($tag->data);
+        if ($tag !== null && isset($this->rawBodyTags[$tag[1]])) {
+            $this->lexRawBodyTag($tag[1]);
         }
     }
 
@@ -366,7 +369,7 @@ class Lexer
             return;
         }
 
-        $this->tokens[] = new Token($type, $value, $this->lineNumber);
+        $this->tokens[] = [$type, $value, $this->lineNumber];
     }
 
     /**
@@ -379,7 +382,7 @@ class Lexer
     protected function pushPunctuation(TokenType $type): void
     {
         $cursor = $this->cursor;
-        $this->tokens[] = new Token($type, $this->source[$cursor], $this->lineNumber);
+        $this->tokens[] = [$type, $this->source[$cursor], $this->lineNumber];
 
         $cursor++;
         $this->cursor = $cursor;
@@ -595,7 +598,7 @@ class Lexer
         // Identifiers are the most common token and can never span a newline, so
         // advance directly rather than paying for pushToken() + skip() and the
         // newline scan skip() would run.
-        $this->tokens[] = new Token($type, $value, $this->lineNumber);
+        $this->tokens[] = [$type, $value, $this->lineNumber];
         $this->cursor = $offset;
         $this->current = $offset < $this->end ? $this->source[$offset] : null;
     }

--- a/src/Parse/Parser.php
+++ b/src/Parse/Parser.php
@@ -52,15 +52,15 @@ class Parser
         $nodes = [];
 
         while (! $this->tokenStream->isEnd()) {
-            $token = $this->tokenStream->next();
-            $this->parseContext->lineNumber = $token->lineNumber;
+            $token = $this->tokenStream->nextRaw();
+            $this->parseContext->lineNumber = $token[2];
 
-            switch ($token->type) {
+            switch ($token[0]) {
                 case TokenType::TextData:
-                    $nodes[] = (new Text($token->data))->setLineNumber($this->parseContext->lineNumber);
+                    $nodes[] = (new Text($token[1]))->setLineNumber($this->parseContext->lineNumber);
                     break;
                 case TokenType::RawData:
-                    $nodes[] = (new Raw($token->data))->setLineNumber($this->parseContext->lineNumber);
+                    $nodes[] = (new Raw($token[1]))->setLineNumber($this->parseContext->lineNumber);
                     break;
                 case TokenType::VariableStart:
                     $nodes[] = $this->parseVariable();
@@ -68,7 +68,7 @@ class Parser
                     break;
                 case TokenType::BlockStart:
                     try {
-                        $tagName = $this->tokenStream->consume(TokenType::Identifier)->data;
+                        $tagName = $this->tokenStream->consumeData(TokenType::Identifier);
                         $this->tokenStream->jump(-1);
                     } catch (SyntaxException $e) {
                         throw new SyntaxException('A block must start with a tag name.');
@@ -81,7 +81,7 @@ class Parser
                     $nodes[] = $this->parseBlock();
                     break;
                 default:
-                    throw new SyntaxException('Unexpected token type: '.$token->type->toString());
+                    throw new SyntaxException('Unexpected token type: '.$token[0]->toString());
             }
         }
 
@@ -102,9 +102,9 @@ class Parser
      */
     protected function parseBlock(): Tag
     {
-        $currentToken = $this->tokenStream->current();
+        $currentLineNumber = $this->tokenStream->currentLineNumber();
 
-        $tagName = $this->tokenStream->consume(TokenType::Identifier)->data;
+        $tagName = $this->tokenStream->consumeData(TokenType::Identifier);
 
         /** @var class-string<Tag>|null $tagClass */
         $tagClass = $this->parseContext->environment->tagRegistry->get($tagName) ?? null;
@@ -115,7 +115,7 @@ class Parser
             throw SyntaxException::unknownTag($tagName, $blockTagName);
         }
 
-        $tag = (new $tagClass)->setLineNumber($currentToken?->lineNumber);
+        $tag = (new $tagClass)->setLineNumber($currentLineNumber);
 
         if ($tag instanceof TagBlock) {
             $this->blockScopes[] = $tag;
@@ -131,7 +131,7 @@ class Parser
                 $tag->parse($tagParseContext);
 
                 try {
-                    $currentTagName = $this->tokenStream->consume(TokenType::Identifier)->data;
+                    $currentTagName = $this->tokenStream->consumeData(TokenType::Identifier);
                 } catch (SyntaxException $e) {
                     throw SyntaxException::tagBlockNeverClosed($tag::tagName());
                 }

--- a/src/Parse/Token.php
+++ b/src/Parse/Token.php
@@ -2,6 +2,19 @@
 
 namespace Keepsuit\Liquid\Parse;
 
+/**
+ * A materialised token.
+ *
+ * The lexer no longer produces these: it emits raw `array{TokenType, string, int}`
+ * triples, because allocating one object per token measurably dominated tokenize
+ * time. Token is built on demand by TokenStream::current(), consume(), next() and
+ * toArray(), for callers that want a value object.
+ *
+ * Hot internal paths use the allocation-free accessors instead
+ * (TokenStream::consumeData(), currentType(), nextRaw(), ...).
+ *
+ * @phpstan-type RawToken array{0: TokenType, 1: string, 2: int}
+ */
 final class Token
 {
     public function __construct(
@@ -9,4 +22,12 @@ final class Token
         public readonly string $data,
         public readonly int $lineNumber,
     ) {}
+
+    /**
+     * @param  RawToken  $token
+     */
+    public static function fromRaw(array $token): self
+    {
+        return new self($token[0], $token[1], $token[2]);
+    }
 }

--- a/src/Parse/TokenStream.php
+++ b/src/Parse/TokenStream.php
@@ -7,8 +7,16 @@ use Keepsuit\Liquid\Exceptions\SyntaxException;
 use Keepsuit\Liquid\Nodes\Variable;
 
 /**
+ * Tokens are stored as raw [TokenType, data, lineNumber] triples rather than
+ * Token objects: the lexer emits thousands per template and the allocation was
+ * measurable. Token instances are materialised on demand by current(), next(),
+ * consume() and toArray(); hot paths use the allocation-free accessors
+ * (consumeData(), currentType(), nextRaw(), consumeIf()).
+ *
  * @phpstan-import-type Argument from ArgumentParser
  * @phpstan-import-type Expression from ExpressionParser
+ *
+ * @phpstan-type RawToken array{0: TokenType, 1: string, 2: int}
  */
 class TokenStream
 {
@@ -21,7 +29,7 @@ class TokenStream
     protected VariableParser $variableParser;
 
     public function __construct(
-        /** @var Token[] */
+        /** @var list<RawToken> */
         protected array $tokens,
         protected ?string $source = null,
     ) {
@@ -48,19 +56,25 @@ class TokenStream
 
     public function look(TokenType $type, int $offset = 0): bool
     {
-        $token = $this->tokens[$this->cursor + $offset] ?? null;
-
-        if ($token === null) {
-            return false;
-        }
-
-        return $token->type === $type;
+        return ($this->tokens[$this->cursor + $offset][0] ?? null) === $type;
     }
 
     /**
      * @throws SyntaxException
      */
     public function next(): Token
+    {
+        return Token::fromRaw($this->nextRaw());
+    }
+
+    /**
+     * Allocation-free next(): returns the raw triple.
+     *
+     * @return RawToken
+     *
+     * @throws SyntaxException
+     */
+    public function nextRaw(): array
     {
         $token = $this->tokens[$this->cursor++] ?? null;
 
@@ -78,17 +92,55 @@ class TokenStream
      */
     public function consume(?TokenType $type = null): Token
     {
+        return Token::fromRaw($this->consumeRaw($type));
+    }
+
+    /**
+     * Allocation-free consume(): returns the raw triple.
+     *
+     * @return RawToken
+     *
+     * @throws SyntaxException
+     */
+    public function consumeRaw(?TokenType $type = null): array
+    {
         $token = $this->tokens[$this->cursor++] ?? null;
 
         if ($token === null) {
             throw SyntaxException::unexpectedEndOfTemplate();
         }
 
-        if ($type !== null && $token->type !== $type) {
-            throw SyntaxException::unexpectedTokenType($type, $token->type);
+        if ($type !== null && $token[0] !== $type) {
+            throw SyntaxException::unexpectedTokenType($type, $token[0]);
         }
 
         return $token;
+    }
+
+    /**
+     * Consume a token and return only its data. The common case in the parsers,
+     * and the reason none of them need a Token instance.
+     *
+     * @throws SyntaxException
+     */
+    public function consumeData(?TokenType $type = null): string
+    {
+        return $this->consumeRaw($type)[1];
+    }
+
+    /**
+     * Allocation-free consumeOrFalse() for callers that only need to know
+     * whether the token was there.
+     */
+    public function consumeIf(TokenType $type): bool
+    {
+        if (($this->tokens[$this->cursor][0] ?? null) !== $type) {
+            return false;
+        }
+
+        $this->cursor++;
+
+        return true;
     }
 
     public function consumeOrFalse(TokenType $type): Token|false
@@ -101,35 +153,71 @@ class TokenStream
      */
     public function id(string $identifier): Token
     {
-        $token = $this->consume(TokenType::Identifier);
+        $token = $this->consumeRaw(TokenType::Identifier);
 
-        if ($token->data !== $identifier) {
-            throw SyntaxException::unexpectedIdentifier($identifier, $token->data);
+        if ($token[1] !== $identifier) {
+            throw SyntaxException::unexpectedIdentifier($identifier, $token[1]);
         }
 
-        return $token;
+        return Token::fromRaw($token);
+    }
+
+    /**
+     * Allocation-free idOrFalse() for callers that only need a yes/no.
+     */
+    public function idIf(string $identifier): bool
+    {
+        $token = $this->tokens[$this->cursor] ?? null;
+
+        if ($token === null || $token[0] !== TokenType::Identifier || $token[1] !== $identifier) {
+            return false;
+        }
+
+        $this->cursor++;
+
+        return true;
     }
 
     public function idOrFalse(string $identifier): Token|false
     {
-        $token = $this->consumeOrFalse(TokenType::Identifier);
-
-        if ($token === false) {
+        if (($this->tokens[$this->cursor][0] ?? null) !== TokenType::Identifier) {
             return false;
         }
 
-        if ($token->data === $identifier) {
-            return $token;
+        $token = $this->tokens[$this->cursor];
+
+        if ($token[1] !== $identifier) {
+            return false;
         }
 
-        $this->jump(-1);
+        $this->cursor++;
 
-        return false;
+        return Token::fromRaw($token);
     }
 
     public function current(): ?Token
     {
+        $token = $this->tokens[$this->cursor] ?? null;
+
+        return $token === null ? null : Token::fromRaw($token);
+    }
+
+    /**
+     * @return RawToken|null
+     */
+    public function currentRaw(): ?array
+    {
         return $this->tokens[$this->cursor] ?? null;
+    }
+
+    public function currentType(): ?TokenType
+    {
+        return $this->tokens[$this->cursor][0] ?? null;
+    }
+
+    public function currentLineNumber(): ?int
+    {
+        return $this->tokens[$this->cursor][2] ?? null;
     }
 
     public function isEnd(): bool
@@ -152,7 +240,7 @@ class TokenStream
      */
     public function simpleVariableName(): string
     {
-        return $this->consume(TokenType::Identifier)->data;
+        return $this->consumeData(TokenType::Identifier);
     }
 
     /**
@@ -182,7 +270,18 @@ class TokenStream
         }
     }
 
+    /**
+     * @return list<Token>
+     */
     public function toArray(): array
+    {
+        return array_map(Token::fromRaw(...), $this->tokens);
+    }
+
+    /**
+     * @return list<RawToken>
+     */
+    public function toRawArray(): array
     {
         return $this->tokens;
     }
@@ -195,29 +294,28 @@ class TokenStream
     public function sliceUntil(Closure|TokenType $check): TokenStream
     {
         if ($check instanceof TokenType) {
-            $tokens = [];
+            $start = $this->cursor;
+            $cursor = $start;
+            $end = count($this->tokens);
 
-            while (! $this->isEnd()) {
-                $token = $this->consume();
-
-                if ($token->type === $check) {
-                    $this->jump(-1);
-                    break;
-                }
-
-                $tokens[] = $token;
+            while ($cursor < $end && $this->tokens[$cursor][0] !== $check) {
+                $cursor++;
             }
 
-            return new TokenStream($tokens);
+            $this->cursor = $cursor;
+
+            return new TokenStream(array_slice($this->tokens, $start, $cursor - $start));
         }
 
+        // Closure form receives a materialised Token; it is only used by tags
+        // such as {% liquid %}, so the allocation is not on a hot path.
         $tokens = [];
 
         while (! $this->isEnd()) {
-            $token = $this->consume();
+            $token = $this->tokens[$this->cursor++];
 
-            if ($check($token)) {
-                $this->jump(-1);
+            if ($check(Token::fromRaw($token))) {
+                $this->cursor--;
                 break;
             }
 

--- a/src/Parse/VariableParser.php
+++ b/src/Parse/VariableParser.php
@@ -16,25 +16,25 @@ class VariableParser
      */
     public function parseVariable(): Variable
     {
-        $currentToken = $this->tokenStream->current();
+        $lineNumber = $this->tokenStream->currentLineNumber();
 
-        if ($currentToken === null) {
+        if ($lineNumber === null) {
             throw SyntaxException::unexpectedEndOfTemplate();
         }
 
         $expression = $this->tokenStream->expression();
 
         $filters = [];
-        while ($this->tokenStream->consumeOrFalse(TokenType::Pipe)) {
-            $filterName = $this->tokenStream->consume(TokenType::Identifier)->data;
-            $filterArgs = $this->tokenStream->consumeOrFalse(TokenType::Colon) ? $this->parseFilterArgs() : [];
+        while ($this->tokenStream->consumeIf(TokenType::Pipe)) {
+            $filterName = $this->tokenStream->consumeData(TokenType::Identifier);
+            $filterArgs = $this->tokenStream->consumeIf(TokenType::Colon) ? $this->parseFilterArgs() : [];
             $filters[] = $this->parseFilterExpressions($filterName, $filterArgs);
         }
 
         return (new Variable(
             name: $expression,
             filters: $filters,
-        ))->setLineNumber($currentToken->lineNumber);
+        ))->setLineNumber($lineNumber);
     }
 
     /**
@@ -44,7 +44,7 @@ class VariableParser
     {
         $filterArgs = [$this->tokenStream->argument()];
 
-        while ($this->tokenStream->consumeOrFalse(TokenType::Comma)) {
+        while ($this->tokenStream->consumeIf(TokenType::Comma)) {
             if ($this->tokenStream->isEnd() || $this->tokenStream->look(TokenType::VariableEnd)) {
                 throw SyntaxException::unexpectedEndOfTemplate();
             }

--- a/src/Tags/AssignTag.php
+++ b/src/Tags/AssignTag.php
@@ -31,7 +31,7 @@ class AssignTag extends Tag implements HasParseTreeVisitorChildren
         try {
             $this->to = $context->params->simpleVariableName();
 
-            $context->params->consume(TokenType::Equals);
+            $context->params->consumeRaw(TokenType::Equals);
 
             $this->from = $context->params->variable();
 

--- a/src/Tags/CaseTag.php
+++ b/src/Tags/CaseTag.php
@@ -123,7 +123,7 @@ class CaseTag extends TagBlock
 
         $condition = new Condition($this->left, '==', $bodySection->params->expression());
 
-        if ($bodySection->params->idOrFalse('or') || $bodySection->params->consumeOrFalse(TokenType::Comma)) {
+        if ($bodySection->params->idIf('or') || $bodySection->params->consumeIf(TokenType::Comma)) {
             $condition->or($this->recordWhenCondition($bodySection));
         }
 

--- a/src/Tags/CycleTag.php
+++ b/src/Tags/CycleTag.php
@@ -40,7 +40,7 @@ class CycleTag extends Tag implements HasParseTreeVisitorChildren
                     default => throw SyntaxException::unexpectedToken($currentToken),
                 };
 
-                $context->params->consume(TokenType::Colon);
+                $context->params->consumeRaw(TokenType::Colon);
             }
 
             do {
@@ -59,7 +59,7 @@ class CycleTag extends Tag implements HasParseTreeVisitorChildren
                     is_string($variable), is_numeric($variable) => $variable,
                     default => throw SyntaxException::unexpectedToken($currentToken)
                 };
-            } while ($context->params->consumeOrFalse(TokenType::Comma));
+            } while ($context->params->consumeIf(TokenType::Comma));
 
             if ($this->name === null) {
                 $this->name = json_encode($this->variables, JSON_THROW_ON_ERROR);

--- a/src/Tags/ForTag.php
+++ b/src/Tags/ForTag.php
@@ -220,7 +220,7 @@ class ForTag extends TagBlock implements HasParseTreeVisitorChildren
             default => throw new SyntaxException('Invalid variable name'),
         };
 
-        if (! $context->params->idOrFalse('in')) {
+        if (! $context->params->idIf('in')) {
             throw new SyntaxException("For loops require an 'in' clause");
         }
 
@@ -231,10 +231,10 @@ class ForTag extends TagBlock implements HasParseTreeVisitorChildren
         };
 
         $this->name = sprintf('%s-%s', $this->variableName, $this->collection);
-        $this->reversed = $context->params->idOrFalse('reversed') !== false;
+        $this->reversed = $context->params->idIf('reversed');
 
         while ($context->params->look(TokenType::Comma) || $context->params->look(TokenType::Identifier)) {
-            $context->params->consumeOrFalse(TokenType::Comma);
+            $context->params->consumeIf(TokenType::Comma);
 
             $attribute = $context->params->idOrFalse('limit') ?: $context->params->idOrFalse('offset');
 
@@ -242,7 +242,7 @@ class ForTag extends TagBlock implements HasParseTreeVisitorChildren
                 throw new SyntaxException('Invalid attribute in for loop. Valid attributes are limit and offset');
             }
 
-            $context->params->consume(TokenType::Colon);
+            $context->params->consumeRaw(TokenType::Colon);
 
             $this->setAttribute($attribute->data, $context->params);
         }

--- a/src/Tags/LiquidTag.php
+++ b/src/Tags/LiquidTag.php
@@ -45,7 +45,7 @@ class LiquidTag extends Tag
 
         $context->getParseContext()->lineNumber = $currentToken->lineNumber;
 
-        $tagName = $tokens->consume(TokenType::Identifier)->data;
+        $tagName = $tokens->consumeData(TokenType::Identifier);
 
         /** @var class-string<Tag>|null $tagClass */
         $tagClass = $context->getParseContext()->environment->tagRegistry->get($tagName) ?? null;

--- a/src/Tags/RenderTag.php
+++ b/src/Tags/RenderTag.php
@@ -54,18 +54,18 @@ class RenderTag extends Tag implements CanBeStreamed, HasParseTreeVisitorChildre
                     default => throw new SyntaxException('Template name must be a string'),
                 };
 
-                $context->params->consumeOrFalse(TokenType::Comma);
+                $context->params->consumeIf(TokenType::Comma);
 
-                if ($context->params->idOrFalse('for')) {
+                if ($context->params->idIf('for')) {
                     $this->isForLoop = true;
                     $this->variableNameExpression = $context->params->expression();
-                } elseif ($context->params->idOrFalse('with')) {
+                } elseif ($context->params->idIf('with')) {
                     $this->variableNameExpression = $context->params->expression();
                 }
 
-                $context->params->consumeOrFalse(TokenType::Comma);
+                $context->params->consumeIf(TokenType::Comma);
 
-                if ($context->params->idOrFalse('as')) {
+                if ($context->params->idIf('as')) {
                     $aliasName = $context->params->expression();
                     $this->aliasName = match (true) {
                         is_string($aliasName), $aliasName instanceof VariableLookup => (string) $aliasName,
@@ -76,14 +76,14 @@ class RenderTag extends Tag implements CanBeStreamed, HasParseTreeVisitorChildre
                 }
 
                 while (! $context->params->isEnd()) {
-                    $context->params->consumeOrFalse(TokenType::Comma);
+                    $context->params->consumeIf(TokenType::Comma);
 
                     $attributeName = $context->params->expression();
                     if (! (is_string($attributeName) || $attributeName instanceof VariableLookup)) {
                         throw new SyntaxException('Attribute name must be a valid variable name');
                     }
 
-                    $context->params->consume(TokenType::Colon);
+                    $context->params->consumeRaw(TokenType::Colon);
                     $attributeValue = $context->params->expression();
 
                     $this->attributes[(string) $attributeName] = $attributeValue;

--- a/src/Tags/TableRowTag.php
+++ b/src/Tags/TableRowTag.php
@@ -37,19 +37,19 @@ class TableRowTag extends TagBlock
 
             $this->body = $context->body;
 
-            $this->variableName = $context->params->consume(TokenType::Identifier)->data;
+            $this->variableName = $context->params->consumeData(TokenType::Identifier);
             $context->params->id('in');
             $this->collectionName = $context->params->expression();
 
             while (true) {
-                $context->params->consumeOrFalse(TokenType::Comma);
+                $context->params->consumeIf(TokenType::Comma);
 
                 if ($context->params->isEnd()) {
                     break;
                 }
 
-                $attribute = $context->params->consume(TokenType::Identifier)->data;
-                $context->params->consume(TokenType::Colon);
+                $attribute = $context->params->consumeData(TokenType::Identifier);
+                $context->params->consumeRaw(TokenType::Colon);
                 $value = $context->params->expression();
                 $this->attributes[$attribute] = $value;
             }


### PR DESCRIPTION
Tests improvement **#2** from the parsing-phase survey, based against `feat/lexer-rewrite` so the CI benchmark compares it directly to the current lexer work rather than to `main`.

## Verdict up front: this is a tokenize win and a net compile loss

Measured locally against `a9f7db3`, 12 interleaved pairs, medians:

| | base | flat tokens | delta |
|---|---:|---:|---:|
| tokenize | 3.242 ms | 2.558 ms | **+21.1%** |
| compile | 5.343 ms | 5.380 ms | **−0.7%** |
| parse-only | 2.101 ms | 2.822 ms | **−34.3%** |

The lexer gets substantially faster, and the parse phase gets slower by slightly more than the lexer gains.

## Why — it's memory, not allocation count

The original estimate came from an allocation microbenchmark and was wrong about the mechanism. Measured footprint for the 6,228-token corpus:

| representation | bytes/token | vs objects |
|---|---:|---:|
| `Token` object | 127.4 | 1.00x |
| `[type, data, line]` array | 237.7 | **1.87x** |
| 3 parallel arrays (SoA) | 65.1 | 0.51x |

PHP objects with declared properties are compact; small arrays are not. Retained token memory for the corpus goes **1.38 MB → 2.07 MB**, and every read in the parse phase now touches more memory. Expect `benchParsing` memory to regress in the CI tables.

Token materialisation is not the cause — only 1,322 `Token` instances are built per compile (down from 6,228), and at ~0.083 µs each that is ~0.11 ms, nowhere near the 0.72 ms parse regression.

## What about structure-of-arrays?

SoA is the only representation that beats objects on footprint (65.1 bytes/token). I did not implement it: it requires 3–4 accessor calls per token in the parser instead of one, and per-call overhead is precisely what dominated the previous lexer work — roughly 18,700 extra calls, enough to erase the gain. It would need its own experiment to settle.

## What's in the diff

- Lexer emits raw `[TokenType, data, lineNumber]` triples.
- `Token` survives as a value object, materialised on demand by `current()`, `consume()`, `next()`, `toArray()`.
- New allocation-free accessors: `consumeData()`, `consumeRaw()`, `consumeIf()`, `idIf()`, `currentType()`, `currentLineNumber()`, `currentRaw()`, `nextRaw()`, `toRawArray()`.
- `Parser`, `ExpressionParser`, `VariableParser`, `ArgumentParser` and the tags migrated to them.
- `sliceUntil()` scans the backing array directly instead of one `consume()` per token.

**BREAKING:** tokens are no longer objects internally, and `TokenStream::toArray()` returns freshly built `Token` instances, so identity comparison no longer holds.

## Correctness

798 tests pass, PHPStan and Pint clean. A differential run over every `.liquid` file in the repo plus 22 edge cases and 7 error cases compares token type/data/line, parse-tree hashes and error messages: **8,634 lines, identical** to the base branch.

## Recommendation

Don't merge as-is. It trades a 21% tokenize win for a 34% parse regression and ~50% more token memory. Worth keeping around if someone wants to try the SoA variant on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
